### PR TITLE
Update to the latest abi-next branch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,6 +1142,7 @@ name = "test-wasmtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitflags",
  "wasi-cap-std-sync",
  "wasmtime",
  "wasmtime-wasi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458e98ed00e4276d0ac60da888d80957a177dfa7efa8dbb3be59f1e2b0e02ae5"
 dependencies = [
- "rand 0.8.3",
+ "rand",
 ]
 
 [[package]]
@@ -231,18 +231,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.72.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841476ab6d3530136b5162b64a2c6969d68141843ad2fd59126e5ea84fd9b5fe"
+checksum = "8b92a3c47b9782066c0e977dfbc444fc2ffde3572135737154034aa5fc926ecd"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.72.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5619cef8d19530298301f91e9a0390d369260799a3d8dd01e28fc88e53637a"
+checksum = "9356227436c0948fe0227ea48d1e6cbfbd6f196a87428d55fd3f910d32e4dc9e"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.72.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a319709b8267939155924114ea83f2a5b5af65ece3ac6f703d4735f3c66bb0d"
+checksum = "9c94789e0a32de783a741775bc87616d589cb1daa95b6d8a46b687ddfba179ff"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -270,27 +270,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.72.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15925b23cd3a448443f289d85a8f53f3cf7a80f0137aa53c8e3b01ae8aefaef7"
+checksum = "06fd3d31bf5988acb52647ec5e491eaf29755e57022dcdffc78297b8940fbec5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.72.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610cf464396c89af0f9f7c64b5aa90aa9e8812ac84084098f1565b40051bc415"
+checksum = "8ad4c7a77e1aec97f9c164b4a3b78b7b817b1fc6ae0aa719a959abe871db25e3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.72.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d20c8bd4a1c41ded051734f0e33ad1d843a0adc98b9bd975ee6657e2c70cdc9"
+checksum = "fd956fa7f5a30c2d045af28f1653e6fc4197a53121225114179887fe62dc65b1"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.72.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304e100df41f34a5a15291b37bfe0fd7abd0427a2c84195cc69578b4137f9099"
+checksum = "7eb979e286564d616628814058a7a5ec160534e5d3cca6ad48ec7584c59ead0c"
 dependencies = [
  "cranelift-codegen",
  "target-lexicon",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.72.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd473b2917303957e0bfaea6ea9d08b8c93695bee015a611a2514ce5254abc"
+checksum = "dc542a08be884ac7af861d9772f658f1ab6baf741a7fa09d26f2517bcded0ad5"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -504,24 +504,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -635,9 +624,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "log"
@@ -832,37 +821,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -872,16 +838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -890,16 +847,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.3",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -908,7 +856,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core",
 ]
 
 [[package]]
@@ -951,7 +899,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
  "redox_syscall",
 ]
 
@@ -1169,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
+checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
 
 [[package]]
 name = "termcolor"
@@ -1319,21 +1267,15 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b935979b43ace1ed03b14bb90598114822583c77b7616b39f62b0a91952bdc34"
+checksum = "1ca0da3c772f916499a0206ad0d76af5801fcbd72cde97d44cb398ef6dcbbc94"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1353,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b42cc1c6e2f8485b2a3d9f70f13d734225f99e748ef33d88f2ae78592072cc"
+checksum = "90996dae10b031eb73e33a62be0f34746701f5507ce95183b95e201a294807c8"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1370,15 +1312,15 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755a9a4afe3f6cccbbe6d7e965eef44cf260b001f93e547eba84255c1d0187d8"
+checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
 
 [[package]]
 name = "wasmtime"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ea2ad49bb047e10ca292f55cd67040bef14b676d07e7b04ed65fd312d52ece"
+checksum = "88cc3ec55eacb4818ebed477a1bfedf52b26617bbe63f85e3acc4257d07dfa0d"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1386,9 +1328,11 @@ dependencies = [
  "cfg-if",
  "cpp_demangle",
  "indexmap",
+ "lazy_static",
  "libc",
  "log",
  "paste",
+ "psm",
  "region",
  "rustc-demangle",
  "serde",
@@ -1407,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9353a705eb98838d885a4d0186c087167fd5ea087ef3511bdbdf1a79420a1d2d"
+checksum = "598c69c34452b19b73d9d53fe5cc6098ef490754202fcd94853e034a99af67a7"
 dependencies = [
  "anyhow",
  "base64",
@@ -1428,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e769b80abbb89255926f69ba37085f7dd6608c980134838c3c89d7bf6e776bc"
+checksum = "5baeb65c1cef8379533d25cab05f8a395fbe608d326a7ef7f036cf834ea6406a"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1442,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38501788c936a4932b0ddf61135963a4b7d1f549f63a6908ae56a1c86d74fc7b"
+checksum = "77898f4545b684cc6e5fb939365673d1018ee7f1514b8e20b432b8c2efb28cab"
 dependencies = [
  "anyhow",
  "gimli 0.23.0",
@@ -1458,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae793ea1387b2fede277d209bb27285366df58f0a3ae9d59e58a7941dce60fa"
+checksum = "ca65c36c6bafc707faaaa78b18a37aa30aae3badbd598d4ab47114f8672522e7"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1479,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c479ba281bc54236209f43a954fc2a874ca3e5fa90116576b1ae23782948783f"
+checksum = "cfc912bc5a03037e1ecda54251bddd5a683b632eb4d19205dffc78f2ec10a8a4"
 dependencies = [
  "cc",
  "libc",
@@ -1490,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3bd0fae8396473a68a1491559d61776127bb9bea75c9a6a6c038ae4a656eb2"
+checksum = "f88bbc7a54f41a85cab6bc21bcde829d93121cddae61eda5b75cc908766555e4"
 dependencies = [
  "addr2line 0.14.1",
  "anyhow",
@@ -1523,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79fa098a3be8fabc50f5be60f8e47694d569afdc255de37850fc80295485012"
+checksum = "85378fd7f1198d1a42aaa3585bb51bfb0214f870ffef7537be91a0f7932c3327"
 dependencies = [
  "anyhow",
  "more-asserts",
@@ -1537,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81e2106efeef4c01917fd16956a91d39bb78c07cf97027abdba9ca98da3f258"
+checksum = "e5e4bc4ecad91e0ab7e255b03baed6c4e169c8c5e0f479dc56f3d49d28d70b92"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1556,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f747c656ca4680cad7846ae91c57d03f2dd4f4170da77a700df4e21f0d805378"
+checksum = "908c8f9159eb16c1bdb9b06850b8a46a0063276245409186bcdeaf6e3076427c"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1568,23 +1512,25 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "mach",
  "memoffset",
  "more-asserts",
- "psm",
- "rand 0.7.3",
+ "rand",
  "region",
  "thiserror",
  "wasmtime-environ",
+ "wasmtime-fiber",
  "winapi",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5ebd3cfc82606e0332437cb370a9a018e8e2e8480c1bdcc10da93620ffad9e"
+checksum = "1851e7a9e5a33bd3862d384222867dbae15e648200b54f8c20ae4233efedf16d"
 dependencies = [
  "anyhow",
+ "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",
  "wasmtime-wiggle",
@@ -1593,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa44fba6a1709e2f8d59535796e38332121ba86823ce78cc4d3c8e7b3ed531da"
+checksum = "2435e8b0208e8d0dca9aff4270f8a40cde265c5ba3848f86167e870be8812f7b"
 dependencies = [
  "wasmtime",
  "wasmtime-wiggle-macro",
@@ -1605,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle-macro"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505a6f708e4db716f6c8936cee36e7d869448b38961b1b788be0e1852da8ad9"
+checksum = "4e5b8b2f51ce9b7e6f2c9ed73d443c356abfd600644b44bfbc4211b7c193f918"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1645,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80697b8479b8aea64dfa454d593a35d46c2530c30d3e54f1c9c3bf934b52f9b"
+checksum = "e8165b9a4f439d7e8a48880153cec0a3a0a2e74c39074135321539b1c358e198"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -1659,18 +1605,18 @@ dependencies = [
 
 [[package]]
 name = "wiggle-borrow"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df677e1a757a4d3bd4b4ff632a23059cd8570dd93b73962dc96a6eb64e824228"
+checksum = "151fbae7b3c1cb51d8df3d06d5e9060d2938d30ba1a42accbbc89ed0aa60faae"
 dependencies = [
  "wiggle",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a47a1cf5407c9e45c2b0144dae3780bb9812093fd59d69e517239b229173a8"
+checksum = "0e4d94b370af1efe8acad8610aca5af5c1b90d8fc22af7a73dc9bec898d06bce"
 dependencies = [
  "anyhow",
  "heck",
@@ -1683,10 +1629,11 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f4d7ee3dac8c22934a18b52269b63e1cfe75b75575821d756f5f34a2a4ca78"
+checksum = "49d56ea1dbc6cc1eacab2c5e19bf42f38c758575866a69da1ce9287e23c943a3"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
  "wiggle-generate",
@@ -1749,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.10.0"
-source = "git+https://github.com/alexcrichton/WASI?branch=abi-next#00d4af8ef75f9a7350686989f7336ffa482bcd1c"
+source = "git+https://github.com/alexcrichton/WASI?branch=abi-next#70a8c6363fb26be655e59a2587bd191e7baee59b"
 dependencies = [
  "anyhow",
  "log",

--- a/crates/gen-core/Cargo.toml
+++ b/crates/gen-core/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
-witx = "0.10"
+witx = { git = 'https://github.com/alexcrichton/WASI', branch = 'abi-next' }

--- a/crates/gen-core/src/lib.rs
+++ b/crates/gen-core/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, BTreeMap, btree_map::Entry};
+use std::collections::{btree_map::Entry, BTreeMap, HashMap, HashSet};
 use witx::*;
 
 pub use witx;

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -403,6 +403,9 @@ impl Generator for RustWasm {
             src.push_str("}\n");
         }
 
+        // Close the opening `mod`.
+        src.push_str("}");
+
         if self.opts.rustfmt {
             let mut child = Command::new("rustfmt")
                 .stdin(Stdio::piped())
@@ -425,9 +428,6 @@ impl Generator for RustWasm {
             let status = child.wait().unwrap();
             assert!(status.success());
         }
-
-        // Close the opening `mod`.
-        src.push_str("}");
 
         files.push("bindings.rs", &src);
     }

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 use std::mem;
 use std::process::{Command, Stdio};
 use witx_bindgen_gen_core::{witx::*, Files, Generator, TypeInfo, Types};
-use witx_bindgen_gen_rust::{int_repr, wasm_type, TypeMode, TypePrint};
+use witx_bindgen_gen_rust::{int_repr, wasm_type, TypeMode, TypePrint, Visibility};
 
 #[derive(Default)]
 pub struct RustWasm {
@@ -295,6 +295,7 @@ impl Generator for RustWasm {
         self.is_dtor = self.types.is_dtor_func(&func.name);
         self.params = self.print_signature(
             func,
+            Visibility::PubSuper,
             self.is_dtor,
             false,
             if self.is_dtor {
@@ -365,6 +366,7 @@ impl Generator for RustWasm {
         self.in_trait = true;
         self.print_signature(
             func,
+            Visibility::Private,
             false,
             true,
             if self.is_dtor {

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -295,7 +295,7 @@ impl Generator for RustWasm {
         self.is_dtor = self.types.is_dtor_func(&func.name);
         self.params = self.print_signature(
             func,
-            Visibility::PubSuper,
+            Visibility::Pub,
             self.is_dtor,
             false,
             if self.is_dtor {

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -916,7 +916,7 @@ impl Bindgen for RustWasm {
                 self.push_str(&module.to_camel_case());
                 self.push_str(">::");
                 self.push_str(func.name.as_str());
-                self.push_str("(");
+                self.push_str("(super::");
                 self.push_str(module);
                 self.push_str("(),");
                 self.push_str(&operands.join(", "));

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -163,6 +163,8 @@ impl Generator for RustWasm {
         self.in_import = import;
         self.types.analyze(module);
         self.trait_name = module.name().as_str().to_camel_case();
+        self.src
+            .push_str(&format!("mod {} {{", module.name().as_str().to_snake_case()));
     }
 
     fn type_record(&mut self, name: &Id, record: &RecordDatatype, docs: &str) {
@@ -380,9 +382,7 @@ impl Generator for RustWasm {
         trait_.handles.extend(mem::take(&mut self.handles_for_func));
     }
 
-    fn finish(&mut self) -> Files {
-        let mut files = Files::default();
-
+    fn finish(&mut self, files: &mut Files) {
         let mut src = mem::take(&mut self.src);
 
         for (name, trait_) in self.traits.iter() {
@@ -423,8 +423,11 @@ impl Generator for RustWasm {
             let status = child.wait().unwrap();
             assert!(status.success());
         }
+
+        // Close the opening `mod`.
+        src.push_str("}");
+
         files.push("bindings.rs", &src);
-        files
     }
 }
 

--- a/crates/gen-rust-wasm/tests/compile.rs
+++ b/crates/gen-rust-wasm/tests/compile.rs
@@ -5,7 +5,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering::SeqCst},
     Once,
 };
-use witx_bindgen_gen_core::{witx, Generator};
+use witx_bindgen_gen_core::{witx, Files, Generator};
 
 #[test]
 fn smoke() {
@@ -318,7 +318,8 @@ fn witx(src: &str, rust: Option<&str>) {
         let mut opts = witx_bindgen_gen_rust_wasm::Opts::default();
         opts.rustfmt = true;
         opts.unchecked = *unchecked;
-        let files = opts.build().generate(&doc, rust.is_none());
+        let mut files = Files::default();
+        opts.build().generate(&doc, rust.is_none(), &mut files);
         let dir = base.join(format!("t{}", me));
         std::fs::create_dir(&dir).unwrap();
         for (file, contents) in files.iter() {

--- a/crates/gen-rust-wasm/tests/compile.rs
+++ b/crates/gen-rust-wasm/tests/compile.rs
@@ -49,17 +49,26 @@ fn integers() {
         r#"
             include!("bindings.rs");
 
-            fn k(
-                _: u8,
-                _: i8,
-                _: u16,
-                _: i16,
-                _: u32,
-                _: i32,
-                _: u64,
-                _: i64,
-            ) -> (u8, u16) {
-                (0, 0)
+            struct MyX {}
+            fn x() -> &'static MyX {
+                static ME: MyX = MyX {};
+                &ME
+            }
+
+            impl x::X for MyX {
+                fn k(
+                    &self,
+                    _: u8,
+                    _: i8,
+                    _: u16,
+                    _: i16,
+                    _: u32,
+                    _: i32,
+                    _: u64,
+                    _: i64,
+                ) -> (u8, u16) {
+                    (0, 0)
+                }
             }
         "#,
     );

--- a/crates/gen-rust-wasm/tests/compile.rs
+++ b/crates/gen-rust-wasm/tests/compile.rs
@@ -9,8 +9,6 @@ use witx_bindgen_gen_core::{witx, Files, Generator};
 
 #[test]
 fn smoke() {
-    import("");
-    export("", "include!(\"bindings.rs\");");
     import("(module $x)");
     export("(module $x)", "include!(\"bindings.rs\");");
     import("(module $x (export \"y\" (func)))");
@@ -125,34 +123,34 @@ fn records() {
     import("(module $x (export \"y\" (func (result $a char) (result $b u32))))");
     import(
         "
-            (typename $a (record))
             (module $x
+                (typename $a (record))
                 (export \"a\" (func (param $a $a) (result $b $a)))
             )
         ",
     );
     import(
         "
-            (typename $a (record (field $a u32) (field $b f32)))
             (module $x
+                (typename $a (record (field $a u32) (field $b f32)))
                 (export \"a\" (func (param $a $a) (result $b $a)))
             )
         ",
     );
     import(
         "
-            (typename $a (record (field $a u32) (field $b f32)))
-            (typename $b (record (field $a $a)))
             (module $x
+                (typename $a (record (field $a u32) (field $b f32)))
+                (typename $b (record (field $a $a)))
                 (export \"a\" (func (param $a $b) (result $b $b)))
             )
         ",
     );
     export(
         "
-            (typename $a (record (field $a u32) (field $b f32)))
-            (typename $b (record (field $a $a)))
             (module $x
+                (typename $a (record (field $a u32) (field $b f32)))
+                (typename $b (record (field $a $a)))
                 (export \"y\" (func
                     (param $a (tuple s32 u32))
                     (result $b (tuple f64))
@@ -183,43 +181,43 @@ fn variants() {
     import("(module $x (export \"y\" (func (param $a (expected (error))) (result $b (expected (error))))))");
     import(
         "
-            (typename $a (enum $a $b $c))
             (module $x
+                (typename $a (enum $a $b $c))
                 (export \"a\" (func (param $a $a) (result $b $a)))
             )
         ",
     );
     import(
         "
-            (typename $a (union f32 f64))
             (module $x
+                (typename $a (union f32 f64))
                 (export \"a\" (func (param $a $a) (result $b $a)))
             )
         ",
     );
     import(
         "
-            (typename $a (variant
-                (case $a s8)
-                (case $b f32)
-                (case $c)
-                (case $d (tuple f64 f64))
-            ))
             (module $x
+                (typename $a (variant
+                    (case $a s8)
+                    (case $b f32)
+                    (case $c)
+                    (case $d (tuple f64 f64))
+                ))
                 (export \"a\" (func (param $a $a) (result $b $a)))
             )
         ",
     );
     export(
         "
-            (typename $a (union f32 u32))
-            (typename $b (variant
-                (case $a s8)
-                (case $b f32)
-                (case $c)
-                (case $d (tuple f64 f64))
-            ))
             (module $x
+                (typename $a (union f32 u32))
+                (typename $b (variant
+                    (case $a s8)
+                    (case $b f32)
+                    (case $c)
+                    (case $d (tuple f64 f64))
+                ))
                 (export \"y\" (func
                     (param $a bool)
                     (result $b $a)

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -9,6 +9,13 @@ pub enum TypeMode {
     HandlesBorrowed(&'static str),
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum Visibility {
+    Pub,
+    PubSuper,
+    Private,
+}
+
 pub trait TypePrint {
     fn krate(&self) -> &'static str;
     fn tmp(&mut self) -> usize;
@@ -72,11 +79,12 @@ pub trait TypePrint {
     fn print_signature(
         &mut self,
         func: &Function,
+        visibility: Visibility,
         unsafe_: bool,
         self_arg: bool,
         param_mode: TypeMode,
     ) -> Vec<String> {
-        let params = self.print_docs_and_params(func, unsafe_, self_arg, param_mode);
+        let params = self.print_docs_and_params(func, visibility, unsafe_, self_arg, param_mode);
         if func.results.len() > 0 {
             self.push_str(" -> ");
             self.print_results(func);
@@ -87,6 +95,7 @@ pub trait TypePrint {
     fn print_docs_and_params(
         &mut self,
         func: &Function,
+        visibility: Visibility,
         unsafe_: bool,
         self_arg: bool,
         param_mode: TypeMode,
@@ -96,6 +105,11 @@ pub trait TypePrint {
         self.rustdoc_params(&func.params, "Parameters");
         self.rustdoc_params(&func.results, "Return");
 
+        match visibility {
+            Visibility::Pub => self.push_str("pub "),
+            Visibility::PubSuper => self.push_str("pub(super) "),
+            Visibility::Private => (),
+        }
         if unsafe_ {
             self.push_str("unsafe ");
         }

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -12,7 +12,6 @@ pub enum TypeMode {
 #[derive(Debug, Copy, Clone)]
 pub enum Visibility {
     Pub,
-    PubSuper,
     Private,
 }
 
@@ -107,7 +106,6 @@ pub trait TypePrint {
 
         match visibility {
             Visibility::Pub => self.push_str("pub "),
-            Visibility::PubSuper => self.push_str("pub(super) "),
             Visibility::Private => (),
         }
         if unsafe_ {

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -878,6 +878,9 @@ impl Generator for Wasmtime {
         }
         self.print_intrinsics();
 
+        // Close the opening `mod`.
+        self.push_str("}");
+
         let mut src = mem::take(&mut self.src);
         if self.opts.rustfmt {
             let mut child = Command::new("rustfmt")
@@ -901,9 +904,6 @@ impl Generator for Wasmtime {
             let status = child.wait().unwrap();
             assert!(status.success());
         }
-
-        // Close the opening `mod`.
-        src.push_str("}");
 
         files.push("bindings.rs", &src);
     }

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 use std::mem;
 use std::process::{Command, Stdio};
 use witx_bindgen_gen_core::{witx::*, Files, Generator, TypeInfo, Types};
-use witx_bindgen_gen_rust::{int_repr, wasm_type, TypeMode, TypePrint};
+use witx_bindgen_gen_rust::{int_repr, wasm_type, TypeMode, TypePrint, Visibility};
 
 #[derive(Default)]
 pub struct Wasmtime {
@@ -494,6 +494,7 @@ impl Generator for Wasmtime {
         self.in_trait = true;
         self.print_signature(
             func,
+            Visibility::Private,
             false,
             true,
             if self.is_dtor {
@@ -592,8 +593,13 @@ impl Generator for Wasmtime {
         if self.is_dtor {
             assert_eq!(func.results.len(), 0, "destructors cannot have results");
         }
-        self.push_str("pub ");
-        self.params = self.print_docs_and_params(func, false, true, TypeMode::AllBorrowed("'_"));
+        self.params = self.print_docs_and_params(
+            func,
+            Visibility::Pub,
+            false,
+            true,
+            TypeMode::AllBorrowed("'_"),
+        );
         self.push_str("-> Result<");
         self.print_results(func);
         self.push_str(", wasmtime::Trap> {\n");

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -324,6 +324,8 @@ impl Generator for Wasmtime {
         self.types.analyze(module);
         self.in_import = import;
         self.trait_name = module.name().as_str().to_camel_case();
+        self.src
+            .push_str(&format!("mod {} {{", module.name().as_str().to_snake_case()));
     }
 
     fn type_record(&mut self, name: &Id, record: &RecordDatatype, docs: &str) {
@@ -668,9 +670,7 @@ impl Generator for Wasmtime {
         );
     }
 
-    fn finish(&mut self) -> Files {
-        let mut files = Files::default();
-
+    fn finish(&mut self, files: &mut Files) {
         for (module, funcs) in sorted_iter(&self.imports) {
             self.src.push_str("\npub trait ");
             self.src.push_str(&module.as_str().to_camel_case());
@@ -895,8 +895,11 @@ impl Generator for Wasmtime {
             let status = child.wait().unwrap();
             assert!(status.success());
         }
+
+        // Close the opening `mod`.
+        src.push_str("}");
+
         files.push("bindings.rs", &src);
-        files
     }
 }
 

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -776,7 +776,8 @@ impl Generator for Wasmtime {
             self.push_str("pub struct ");
             self.push_str(&name);
             self.push_str("{\n");
-            self.push_str("instance: wasmtime::Instance,\n");
+            // Use `pub(super)` so that crates/test-wasmtime/src/exports.rs can access it.
+            self.push_str("pub(super) instance: wasmtime::Instance,\n");
             for (name, (ty, _)) in exports.fields.iter() {
                 self.push_str(name);
                 self.push_str(": ");

--- a/crates/rust-wasm-impl/src/lib.rs
+++ b/crates/rust-wasm-impl/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{token, Token};
-use witx_bindgen_gen_core::{witx, Generator, Files};
+use witx_bindgen_gen_core::{witx, Files, Generator};
 
 #[proc_macro]
 pub fn import(input: TokenStream) -> TokenStream {
@@ -54,7 +54,10 @@ impl Parse for Opts {
                 }
             }
             if modules.is_empty() {
-                return Err(Error::new(call_site, "must either specify `src` or `paths` keys"));
+                return Err(Error::new(
+                    call_site,
+                    "must either specify `src` or `paths` keys",
+                ));
             }
             modules
         } else {

--- a/crates/rust-wasm-impl/src/lib.rs
+++ b/crates/rust-wasm-impl/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{token, Token};
-use witx_bindgen_gen_core::{witx, Generator};
+use witx_bindgen_gen_core::{witx, Generator, Files};
 
 #[proc_macro]
 pub fn import(input: TokenStream) -> TokenStream {
@@ -17,14 +17,17 @@ pub fn export(input: TokenStream) -> TokenStream {
 fn run(input: TokenStream, import: bool) -> TokenStream {
     let input = syn::parse_macro_input!(input as Opts);
     let mut gen = input.opts.build();
-    let files = gen.generate(&input.module, import);
+    let mut files = Files::default();
+    for module in input.modules {
+        gen.generate(&module, import, &mut files);
+    }
     let (_, contents) = files.iter().next().unwrap();
     contents.parse().unwrap()
 }
 
 struct Opts {
     opts: witx_bindgen_gen_rust_wasm::Opts,
-    module: witx::Module,
+    modules: Vec<witx::Module>,
 }
 
 mod kw {
@@ -38,41 +41,41 @@ impl Parse for Opts {
     fn parse(input: ParseStream<'_>) -> Result<Opts> {
         let mut opts = witx_bindgen_gen_rust_wasm::Opts::default();
         let call_site = proc_macro2::Span::call_site();
-        let module = if input.peek(token::Brace) {
+        let modules = if input.peek(token::Brace) {
             let content;
             syn::braced!(content in input);
-            let mut module = None;
+            let mut modules = Vec::new();
             let fields = Punctuated::<ConfigField, Token![,]>::parse_terminated(&content)?;
             for field in fields.into_pairs() {
                 match field.into_value() {
                     ConfigField::Unchecked => opts.unchecked = true,
                     ConfigField::MultiModule => opts.multi_module = true,
-                    ConfigField::Module(m) => module = Some(m),
+                    ConfigField::Modules(m) => modules = m,
                 }
             }
-            module
-                .ok_or_else(|| Error::new(call_site, "must either specify `src` or `paths` keys"))?
+            if modules.is_empty() {
+                return Err(Error::new(call_site, "must either specify `src` or `paths` keys"));
+            }
+            modules
         } else {
             let mut paths = Vec::new();
             while !input.is_empty() {
                 let s = input.parse::<syn::LitStr>()?;
                 paths.push(s.value());
             }
-            if paths.len() == 1 {
-                witx::load(&paths[0]).map_err(|e| Error::new(call_site, e.report()))?
-            } else {
-                return Err(Error::new(
-                    call_site,
-                    "exactly one path is supported right now",
-                ));
+            let mut modules = Vec::new();
+            for path in &paths {
+                let module = witx::load(&path).map_err(|e| Error::new(call_site, e.report()))?;
+                modules.push(module);
             }
+            modules
         };
-        Ok(Opts { opts, module })
+        Ok(Opts { opts, modules })
     }
 }
 
 enum ConfigField {
-    Module(witx::Module),
+    Modules(Vec<witx::Module>),
     Unchecked,
     MultiModule,
 }
@@ -85,7 +88,7 @@ impl Parse for ConfigField {
             input.parse::<Token![:]>()?;
             let s = input.parse::<syn::LitStr>()?;
             let module = witx::parse(&s.value()).map_err(|e| Error::new(s.span(), e.report()))?;
-            Ok(ConfigField::Module(module))
+            Ok(ConfigField::Modules(vec![module]))
         } else if l.peek(kw::paths) {
             input.parse::<kw::paths>()?;
             input.parse::<Token![:]>()?;
@@ -93,15 +96,12 @@ impl Parse for ConfigField {
             let bracket = syn::bracketed!(paths in input);
             let paths = Punctuated::<syn::LitStr, Token![,]>::parse_terminated(&paths)?;
             let values = paths.iter().map(|s| s.value()).collect::<Vec<_>>();
-            if values.len() != 1 {
-                return Err(Error::new(
-                    bracket.span,
-                    "only exactly one path is supported right now",
-                ));
+            let mut modules = Vec::new();
+            for value in &values {
+                let module = witx::load(value).map_err(|e| Error::new(bracket.span, e.report()))?;
+                modules.push(module);
             }
-            let module =
-                witx::load(&values[0]).map_err(|e| Error::new(bracket.span, e.report()))?;
-            Ok(ConfigField::Module(module))
+            Ok(ConfigField::Modules(modules))
         } else if l.peek(kw::unchecked) {
             input.parse::<kw::unchecked>()?;
             Ok(ConfigField::Unchecked)

--- a/crates/test-rust-wasm/src/exports.rs
+++ b/crates/test-rust-wasm/src/exports.rs
@@ -4,6 +4,8 @@ witx_bindgen_rust::export!("tests/wasm.witx");
 #[cfg(feature = "unchecked")]
 witx_bindgen_rust::export!({ paths: ["tests/wasm.witx"], unchecked });
 
+use wasm::*;
+
 use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
 use witx_bindgen_rust::exports::{InBuffer, InBufferRaw, OutBuffer, OutBufferRaw};
 

--- a/crates/test-rust-wasm/src/imports.rs
+++ b/crates/test-rust-wasm/src/imports.rs
@@ -4,6 +4,8 @@ witx_bindgen_rust::import!("tests/host.witx");
 #[cfg(feature = "unchecked")]
 witx_bindgen_rust::import!({ paths: ["tests/host.witx"], unchecked });
 
+use host::*;
+
 use std::iter;
 
 use crate::allocator;

--- a/crates/test-wasmtime/Cargo.toml
+++ b/crates/test-wasmtime/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-wasmtime = "0.25.0"
-wasmtime-wasi = "0.25.0"
-wasi-cap-std-sync = "0.25.0"
+wasmtime = "0.26.0"
+wasmtime-wasi = "0.26.0"
+wasi-cap-std-sync = "0.26.0"
 witx-bindgen-wasmtime = { path = "../wasmtime" }

--- a/crates/test-wasmtime/Cargo.toml
+++ b/crates/test-wasmtime/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
+bitflags = "1.2.1"
 wasmtime = "0.26.0"
 wasmtime-wasi = "0.26.0"
 wasi-cap-std-sync = "0.26.0"

--- a/crates/test-wasmtime/src/exports.rs
+++ b/crates/test-wasmtime/src/exports.rs
@@ -3,6 +3,9 @@ use std::iter;
 use wasmtime::Instance;
 
 witx_bindgen_wasmtime::export!("tests/wasm.witx");
+use wasm::*;
+
+pub(crate) use wasm::Wasm;
 
 pub fn test(wasm: &Wasm) -> Result<()> {
     let bytes = wasm.allocated_bytes()?;

--- a/crates/test-wasmtime/src/imports.rs
+++ b/crates/test-wasmtime/src/imports.rs
@@ -3,6 +3,9 @@ use witx_bindgen_wasmtime::imports::{InBuffer, OutBuffer};
 use witx_bindgen_wasmtime::{BorrowChecker, GuestPtr, Table};
 
 witx_bindgen_wasmtime::import!("tests/host.witx");
+use host::*;
+
+pub(crate) use host::add_host_to_linker;
 
 #[derive(Default)]
 pub struct MyHost {

--- a/crates/wasmtime-impl/src/lib.rs
+++ b/crates/wasmtime-impl/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use syn::parse::{Error, Parse, ParseStream, Result};
-use witx_bindgen_gen_core::{witx, Generator, Files};
+use witx_bindgen_gen_core::{witx, Files, Generator};
 
 #[proc_macro]
 pub fn import(input: TokenStream) -> TokenStream {

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 anyhow = "1.0"
 bitflags = "1.2"
 thiserror = "1.0"
-wasmtime = "0.25"
+wasmtime = "0.26.0"
 witx-bindgen-wasmtime-impl = { path = "../wasmtime-impl", version = "0.1" }

--- a/src/bin/witx-bindgen.rs
+++ b/src/bin/witx-bindgen.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 use structopt::StructOpt;
-use witx_bindgen_gen_core::{witx, Generator};
+use witx_bindgen_gen_core::{witx, Files, Generator};
 
 #[derive(Debug, StructOpt)]
 struct Opt {
@@ -54,16 +54,12 @@ fn main() -> Result<()> {
         anyhow::bail!("one of `--import` or `--export` must be used");
     }
 
-    anyhow::ensure!(
-        common.witx.len() < 2,
-        "at most one *.witx file is supported right now"
-    );
-    if common.witx.is_empty() {
-        return Ok(());
+    let mut files = Files::default();
+    for witx in common.witx {
+        let module = witx::load(witx)?;
+        generator.generate(&module, common.import, &mut files);
     }
 
-    let doc = witx::load(&common.witx[0])?;
-    let files = generator.generate(&doc, common.import);
     for (name, contents) in files.iter() {
         let dst = match &common.out_dir {
             Some(path) => path.join(name),

--- a/tests/host.witx
+++ b/tests/host.witx
@@ -1,108 +1,106 @@
-(typename $f1 (flags $a $b))
-(typename $f2 (flags (@witx repr u64) $c $d $e))
-(typename $r1 (record (field $a u8) (field $b $f1)))
-(typename $e1 (enum $a $b))
-
-;; Variants for testing casting between primitive types
-(typename $c1 (variant (case $a s32) (case $b s64)))
-(typename $c2 (variant (case $a s32) (case $b f32)))
-(typename $c3 (variant (case $a s32) (case $b f64)))
-(typename $c4 (variant (case $a s64) (case $b f32)))
-(typename $c5 (variant (case $a s64) (case $b f64)))
-(typename $c6 (variant (case $a f32) (case $b f64)))
-(typename $casts (tuple $c1 $c2 $c3 $c4 $c5 $c6))
-
-;; Variants for testing zeros can be synthesized
-(typename $z1 (variant (case $a s32) (case $b)))
-(typename $z2 (variant (case $a s64) (case $b)))
-(typename $z3 (variant (case $a f32) (case $b)))
-(typename $z4 (variant (case $a f64) (case $b)))
-(typename $zeros (tuple $z1 $z2 $z3 $z4))
-
-(typename $s8 s8)
-(typename $u8 u8)
-(typename $s16 s16)
-(typename $u16 u16)
-(typename $s32 s32)
-(typename $u32 u32)
-(typename $s64 s64)
-(typename $u64 u64)
-(typename $f32 f32)
-(typename $f64 f64)
-(typename $legacy_result (tuple
-    ;; primitives with varying bit widths and signedness
-    $s8 $u8
-    $s16 $u16
-    $s32 $u32
-    $s64 $u64
-    $f32 $f64
-    ;; records
-    $r1
-))
-
-(typename $unused_type (record (field $a string)))
-
-(typename $list_in_record1 (record (field $a string)))
-(typename $list_in_record2 (record (field $a string)))
-(typename $list_in_record3 (record (field $a string)))
-(typename $list_in_record4 (record (field $a string)))
-
-(typename $option_typedef (option u32))
-(typename $bool_typedef bool)
-(typename $result_typedef (expected u32 (error)))
-
-(typename $list_in_variant1_1 (option string))
-(typename $list_in_variant1_2 (expected (error string)))
-(typename $list_in_variant1_3 (union string f32))
-(typename $list_in_variant2 (option string))
-(typename $list_in_variant3 (option string))
-
-(typename $my_errno (enum $success $a $b))
-
-(typename $list_in_alias $list_in_record4)
-(typename $list_typedef string)
-(typename $list_typedef2 (list u8))
-(typename $list_typedef3 (list string))
-
-(resource $host_state_resource)
-(typename $host_state (handle $host_state_resource))
-
-(resource $host_state_resource2)
-(typename $host_state2 (handle $host_state_resource2))
-
-(typename $host_state_param_record (record (field $a $host_state2)))
-(typename $host_state_param_tuple (tuple $host_state2))
-(typename $host_state_param_option (option $host_state2))
-(typename $host_state_param_result (expected $host_state2 (error u32)))
-(typename $host_state_param_variant (union $host_state2 u32))
-
-(typename $host_state_result_record (record (field $a $host_state2)))
-(typename $host_state_result_tuple (tuple $host_state2))
-(typename $host_state_result_option (option $host_state2))
-(typename $host_state_result_result (expected $host_state2 (error u32)))
-(typename $host_state_result_variant (union $host_state2 u32))
-
-(typename $buffer_in_variant (variant
-  (case $a (in-buffer u8))
-  (case $b (out-buffer u8))
-  (case $c (in-buffer bool))
-  (case $d (out-buffer bool))
-))
-
-(typename $buffer_in_record (record
-  (field $a (in-buffer u8))
-  (field $b (out-buffer u8))
-  (field $c (in-buffer bool))
-  (field $d (out-buffer bool))
-  (field $e $buffer_in_variant)
-))
-
-(typename $param_in_buffer_u8 (in-buffer u8))
-(typename $param_out_buffer_u8 (out-buffer u8))
-(typename $param_in_buffer_bool (in-buffer bool))
-(typename $param_out_buffer_bool (out-buffer bool))
-
 (module $host
+  (typename $f1 (flags $a $b))
+  (typename $f2 (flags (@witx repr u64) $c $d $e))
+  (typename $r1 (record (field $a u8) (field $b $f1)))
+  (typename $e1 (enum $a $b))
+
+  ;; Variants for testing casting between primitive types
+  (typename $c1 (variant (case $a s32) (case $b s64)))
+  (typename $c2 (variant (case $a s32) (case $b f32)))
+  (typename $c3 (variant (case $a s32) (case $b f64)))
+  (typename $c4 (variant (case $a s64) (case $b f32)))
+  (typename $c5 (variant (case $a s64) (case $b f64)))
+  (typename $c6 (variant (case $a f32) (case $b f64)))
+  (typename $casts (tuple $c1 $c2 $c3 $c4 $c5 $c6))
+
+  ;; Variants for testing zeros can be synthesized
+  (typename $z1 (variant (case $a s32) (case $b)))
+  (typename $z2 (variant (case $a s64) (case $b)))
+  (typename $z3 (variant (case $a f32) (case $b)))
+  (typename $z4 (variant (case $a f64) (case $b)))
+  (typename $zeros (tuple $z1 $z2 $z3 $z4))
+
+  (typename $s8 s8)
+  (typename $u8 u8)
+  (typename $s16 s16)
+  (typename $u16 u16)
+  (typename $s32 s32)
+  (typename $u32 u32)
+  (typename $s64 s64)
+  (typename $u64 u64)
+  (typename $f32 f32)
+  (typename $f64 f64)
+  (typename $legacy_result (tuple
+      ;; primitives with varying bit widths and signedness
+      $s8 $u8
+      $s16 $u16
+      $s32 $u32
+      $s64 $u64
+      $f32 $f64
+      ;; records
+      $r1
+  ))
+
+  (typename $unused_type (record (field $a string)))
+
+  (typename $list_in_record1 (record (field $a string)))
+  (typename $list_in_record2 (record (field $a string)))
+  (typename $list_in_record3 (record (field $a string)))
+  (typename $list_in_record4 (record (field $a string)))
+
+  (typename $option_typedef (option u32))
+  (typename $bool_typedef bool)
+  (typename $result_typedef (expected u32 (error)))
+
+  (typename $list_in_variant1_1 (option string))
+  (typename $list_in_variant1_2 (expected (error string)))
+  (typename $list_in_variant1_3 (union string f32))
+  (typename $list_in_variant2 (option string))
+  (typename $list_in_variant3 (option string))
+
+  (typename $my_errno (enum $success $a $b))
+
+  (typename $list_in_alias $list_in_record4)
+  (typename $list_typedef string)
+  (typename $list_typedef2 (list u8))
+  (typename $list_typedef3 (list string))
+
+  (resource $r0)
+  (typename $host_state (handle $r0))
+  (resource $r1)
+  (typename $host_state2 (handle $r1))
+
+  (typename $host_state_param_record (record (field $a $host_state2)))
+  (typename $host_state_param_tuple (tuple $host_state2))
+  (typename $host_state_param_option (option $host_state2))
+  (typename $host_state_param_result (expected $host_state2 (error u32)))
+  (typename $host_state_param_variant (union $host_state2 u32))
+
+  (typename $host_state_result_record (record (field $a $host_state2)))
+  (typename $host_state_result_tuple (tuple $host_state2))
+  (typename $host_state_result_option (option $host_state2))
+  (typename $host_state_result_result (expected $host_state2 (error u32)))
+  (typename $host_state_result_variant (union $host_state2 u32))
+
+  (typename $buffer_in_variant (variant
+    (case $a (in-buffer u8))
+    (case $b (out-buffer u8))
+    (case $c (in-buffer bool))
+    (case $d (out-buffer bool))
+  ))
+
+  (typename $buffer_in_record (record
+    (field $a (in-buffer u8))
+    (field $b (out-buffer u8))
+    (field $c (in-buffer bool))
+    (field $d (out-buffer bool))
+    (field $e $buffer_in_variant)
+  ))
+
+  (typename $param_in_buffer_u8 (in-buffer u8))
+  (typename $param_out_buffer_u8 (out-buffer u8))
+  (typename $param_in_buffer_bool (in-buffer bool))
+  (typename $param_out_buffer_bool (out-buffer bool))
 
   ;; ===========================================
   ;; scalars

--- a/tests/wasm.witx
+++ b/tests/wasm.witx
@@ -1,85 +1,84 @@
-(typename $f1 (flags $a $b))
-(typename $f2 (flags (@witx repr u64) $c $d $e))
-(typename $r1 (record (field $a u8) (field $b $f1)))
-(typename $e1 (enum $a $b))
-
-;; Variants for testing casting between primitive types
-(typename $c1 (variant (case $a s32) (case $b s64)))
-(typename $c2 (variant (case $a s32) (case $b f32)))
-(typename $c3 (variant (case $a s32) (case $b f64)))
-(typename $c4 (variant (case $a s64) (case $b f32)))
-(typename $c5 (variant (case $a s64) (case $b f64)))
-(typename $c6 (variant (case $a f32) (case $b f64)))
-(typename $casts (tuple $c1 $c2 $c3 $c4 $c5 $c6))
-
-;; Variants for testing zeros can be synthesized
-(typename $z1 (variant (case $a s32) (case $b)))
-(typename $z2 (variant (case $a s64) (case $b)))
-(typename $z3 (variant (case $a f32) (case $b)))
-(typename $z4 (variant (case $a f64) (case $b)))
-(typename $zeros (tuple $z1 $z2 $z3 $z4))
-
-(typename $option_typedef (option u32))
-(typename $bool_typedef bool)
-(typename $result_typedef (expected u32 (error)))
-
-(typename $list_in_record1 (record (field $a string)))
-(typename $list_in_record2 (record (field $a string)))
-(typename $list_in_record3 (record (field $a string)))
-(typename $list_in_record4 (record (field $a string)))
-
-(typename $list_in_variant1_1 (option string))
-(typename $list_in_variant1_2 (expected (error string)))
-(typename $list_in_variant1_3 (union string f32))
-(typename $list_in_variant2 (option string))
-(typename $list_in_variant3 (option string))
-
-(typename $my_errno (enum $success $a $b))
-
-(typename $list_in_alias $list_in_record4)
-(typename $list_typedef string)
-(typename $list_typedef2 (list u8))
-(typename $list_typedef3 (list string))
-
-(resource $wasm_state_resource)
-(typename $wasm_state (handle $wasm_state_resource))
-
-(resource $wasm_state_resource2)
-(typename $wasm_state2 (handle $wasm_state_resource2))
-
-(typename $wasm_state_param_record (record (field $a $wasm_state2)))
-(typename $wasm_state_param_tuple (tuple $wasm_state2))
-(typename $wasm_state_param_option (option $wasm_state2))
-(typename $wasm_state_param_result (expected $wasm_state2 (error u32)))
-(typename $wasm_state_param_variant (union $wasm_state2 u32))
-
-(typename $wasm_state_result_record (record (field $a $wasm_state2)))
-(typename $wasm_state_result_tuple (tuple $wasm_state2))
-(typename $wasm_state_result_option (option $wasm_state2))
-(typename $wasm_state_result_result (expected $wasm_state2 (error u32)))
-(typename $wasm_state_result_variant (union $wasm_state2 u32))
-
-(typename $buffer_in_variant (variant
-  (case $a (in-buffer u8))
-  (case $b (out-buffer u8))
-  (case $c (in-buffer bool))
-  (case $d (out-buffer bool))
-))
-
-(typename $buffer_in_record (record
-  (field $a (in-buffer u8))
-  (field $b (out-buffer u8))
-  (field $c (in-buffer bool))
-  (field $d (out-buffer bool))
-  (field $e $buffer_in_variant)
-))
-
-(typename $param_in_buffer_u8 (in-buffer u8))
-(typename $param_out_buffer_u8 (out-buffer u8))
-(typename $param_in_buffer_bool (in-buffer bool))
-(typename $param_out_buffer_bool (out-buffer bool))
-
 (module $wasm
+  (typename $f1 (flags $a $b))
+  (typename $f2 (flags (@witx repr u64) $c $d $e))
+  (typename $r1 (record (field $a u8) (field $b $f1)))
+  (typename $e1 (enum $a $b))
+
+  ;; Variants for testing casting between primitive types
+  (typename $c1 (variant (case $a s32) (case $b s64)))
+  (typename $c2 (variant (case $a s32) (case $b f32)))
+  (typename $c3 (variant (case $a s32) (case $b f64)))
+  (typename $c4 (variant (case $a s64) (case $b f32)))
+  (typename $c5 (variant (case $a s64) (case $b f64)))
+  (typename $c6 (variant (case $a f32) (case $b f64)))
+  (typename $casts (tuple $c1 $c2 $c3 $c4 $c5 $c6))
+
+  ;; Variants for testing zeros can be synthesized
+  (typename $z1 (variant (case $a s32) (case $b)))
+  (typename $z2 (variant (case $a s64) (case $b)))
+  (typename $z3 (variant (case $a f32) (case $b)))
+  (typename $z4 (variant (case $a f64) (case $b)))
+  (typename $zeros (tuple $z1 $z2 $z3 $z4))
+
+  (typename $option_typedef (option u32))
+  (typename $bool_typedef bool)
+  (typename $result_typedef (expected u32 (error)))
+
+  (typename $list_in_record1 (record (field $a string)))
+  (typename $list_in_record2 (record (field $a string)))
+  (typename $list_in_record3 (record (field $a string)))
+  (typename $list_in_record4 (record (field $a string)))
+
+  (typename $list_in_variant1_1 (option string))
+  (typename $list_in_variant1_2 (expected (error string)))
+  (typename $list_in_variant1_3 (union string f32))
+  (typename $list_in_variant2 (option string))
+  (typename $list_in_variant3 (option string))
+
+  (typename $my_errno (enum $success $a $b))
+
+  (typename $list_in_alias $list_in_record4)
+  (typename $list_typedef string)
+  (typename $list_typedef2 (list u8))
+  (typename $list_typedef3 (list string))
+
+  (resource $r0)
+  (typename $wasm_state (handle $r0))
+  (resource $r1)
+  (typename $wasm_state2 (handle $r1))
+
+  (typename $wasm_state_param_record (record (field $a $wasm_state2)))
+  (typename $wasm_state_param_tuple (tuple $wasm_state2))
+  (typename $wasm_state_param_option (option $wasm_state2))
+  (typename $wasm_state_param_result (expected $wasm_state2 (error u32)))
+  (typename $wasm_state_param_variant (union $wasm_state2 u32))
+
+  (typename $wasm_state_result_record (record (field $a $wasm_state2)))
+  (typename $wasm_state_result_tuple (tuple $wasm_state2))
+  (typename $wasm_state_result_option (option $wasm_state2))
+  (typename $wasm_state_result_result (expected $wasm_state2 (error u32)))
+  (typename $wasm_state_result_variant (union $wasm_state2 u32))
+
+  (typename $buffer_in_variant (variant
+    (case $a (in-buffer u8))
+    (case $b (out-buffer u8))
+    (case $c (in-buffer bool))
+    (case $d (out-buffer bool))
+  ))
+
+  (typename $buffer_in_record (record
+    (field $a (in-buffer u8))
+    (field $b (out-buffer u8))
+    (field $c (in-buffer bool))
+    (field $d (out-buffer bool))
+    (field $e $buffer_in_variant)
+  ))
+
+  (typename $param_in_buffer_u8 (in-buffer u8))
+  (typename $param_out_buffer_u8 (out-buffer u8))
+  (typename $param_in_buffer_bool (in-buffer bool))
+  (typename $param_out_buffer_bool (out-buffer bool))
+
   (export "run_import_tests" (func))
   (export "allocated_bytes" (func (result $a u32)))
 


### PR DESCRIPTION
This involved some straight-forward API updates, but also involved the transition away from `Document`.

The approach I ended up using here was to to have the rust-wasm backend put each witx module in its own Rust `mod` so that we can generate multiple modules in the same bindings.rs file. That currently means that users have to do things like `use wasm::*` though. I'm open to other ideas here.
