### PR TITLE
Get `witx-bindgen-gen-{core,rust,wasmtime}` and `witx-bindgen` compiling again

### DIFF
--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -159,16 +159,10 @@ impl TypePrint for RustWasm {
 }
 
 impl Generator for RustWasm {
-    fn preprocess(&mut self, doc: &Document, import: bool) {
+    fn preprocess(&mut self, module: &Module, import: bool) {
         self.in_import = import;
-        self.types.analyze(doc);
-        assert!(
-            doc.modules().count() <= 1,
-            "only one module supported at this time"
-        );
-        if let Some(m) = doc.modules().next() {
-            self.trait_name = m.name.as_str().to_camel_case();
-        }
+        self.types.analyze(module);
+        self.trait_name = module.name().as_str().to_camel_case();
     }
 
     fn type_record(&mut self, name: &Id, record: &RecordDatatype, docs: &str) {
@@ -295,7 +289,7 @@ impl Generator for RustWasm {
         ));
     }
 
-    fn import(&mut self, module: &Id, func: &InterfaceFunc) {
+    fn import(&mut self, module: &Id, func: &Function) {
         self.is_dtor = self.types.is_dtor_func(&func.name);
         self.params = self.print_signature(
             func,
@@ -328,7 +322,7 @@ impl Generator for RustWasm {
         self.src.push_str("}");
     }
 
-    fn export(&mut self, module: &Id, func: &InterfaceFunc) {
+    fn export(&mut self, module: &Id, func: &Function) {
         self.is_dtor = self.types.is_dtor_func(&func.name);
         let rust_name = func.name.as_ref().to_snake_case();
 

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -34,7 +34,7 @@ pub trait TypePrint {
         }
     }
 
-    fn rustdoc_params(&mut self, docs: &[InterfaceFuncParam], header: &str) {
+    fn rustdoc_params(&mut self, docs: &[Param], header: &str) {
         let docs = docs
             .iter()
             .filter(|param| param.docs.trim().len() > 0)
@@ -71,7 +71,7 @@ pub trait TypePrint {
 
     fn print_signature(
         &mut self,
-        func: &InterfaceFunc,
+        func: &Function,
         unsafe_: bool,
         self_arg: bool,
         param_mode: TypeMode,
@@ -86,7 +86,7 @@ pub trait TypePrint {
 
     fn print_docs_and_params(
         &mut self,
-        func: &InterfaceFunc,
+        func: &Function,
         unsafe_: bool,
         self_arg: bool,
         param_mode: TypeMode,
@@ -118,7 +118,7 @@ pub trait TypePrint {
         params
     }
 
-    fn print_results(&mut self, func: &InterfaceFunc) {
+    fn print_results(&mut self, func: &Function) {
         match func.results.len() {
             0 => self.push_str("()"),
             1 => {

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -320,16 +320,10 @@ impl TypePrint for Wasmtime {
 }
 
 impl Generator for Wasmtime {
-    fn preprocess(&mut self, doc: &Document, import: bool) {
-        assert!(
-            doc.modules().count() <= 1,
-            "only one module supported at this time"
-        );
-        self.types.analyze(doc);
+    fn preprocess(&mut self, module: &Module, import: bool) {
+        self.types.analyze(module);
         self.in_import = import;
-        if let Some(m) = doc.modules().next() {
-            self.trait_name = m.name.as_str().to_camel_case();
-        }
+        self.trait_name = module.name().as_str().to_camel_case();
     }
 
     fn type_record(&mut self, name: &Id, record: &RecordDatatype, docs: &str) {
@@ -490,7 +484,7 @@ impl Generator for Wasmtime {
         ));
     }
 
-    fn import(&mut self, module: &Id, func: &InterfaceFunc) {
+    fn import(&mut self, module: &Id, func: &Function) {
         self.tmp = 0;
         let prev = mem::take(&mut self.src);
         self.is_dtor = self.types.is_dtor_func(&func.name);
@@ -589,7 +583,7 @@ impl Generator for Wasmtime {
         assert!(self.cleanup.is_none());
     }
 
-    fn export(&mut self, module: &Id, func: &InterfaceFunc) {
+    fn export(&mut self, module: &Id, func: &Function) {
         self.tmp = 0;
         let prev = mem::take(&mut self.src);
         self.is_dtor = self.types.is_dtor_func(&func.name);

--- a/src/bin/witx-bindgen.rs
+++ b/src/bin/witx-bindgen.rs
@@ -54,7 +54,15 @@ fn main() -> Result<()> {
         anyhow::bail!("one of `--import` or `--export` must be used");
     }
 
-    let doc = witx::load(&common.witx)?;
+    anyhow::ensure!(
+        common.witx.len() < 2,
+        "at most one *.witx file is supported right now"
+    );
+    if common.witx.is_empty() {
+        return Ok(());
+    }
+
+    let doc = witx::load(&common.witx[0])?;
     let files = generator.generate(&doc, common.import);
     for (name, contents) in files.iter() {
         let dst = match &common.out_dir {


### PR DESCRIPTION
This doesn't get the test crates compiling or running again, as I think that requires at minimum some updates to the test witx files.