### PR TITLE
Get tests running again

### DIFF
--- a/crates/rust-wasm-impl/src/lib.rs
+++ b/crates/rust-wasm-impl/src/lib.rs
@@ -17,14 +17,14 @@ pub fn export(input: TokenStream) -> TokenStream {
 fn run(input: TokenStream, import: bool) -> TokenStream {
     let input = syn::parse_macro_input!(input as Opts);
     let mut gen = input.opts.build();
-    let files = gen.generate(&input.doc, import);
+    let files = gen.generate(&input.module, import);
     let (_, contents) = files.iter().next().unwrap();
     contents.parse().unwrap()
 }
 
 struct Opts {
     opts: witx_bindgen_gen_rust_wasm::Opts,
-    doc: witx::Document,
+    module: witx::Module,
 }
 
 mod kw {
@@ -38,33 +38,41 @@ impl Parse for Opts {
     fn parse(input: ParseStream<'_>) -> Result<Opts> {
         let mut opts = witx_bindgen_gen_rust_wasm::Opts::default();
         let call_site = proc_macro2::Span::call_site();
-        let doc = if input.peek(token::Brace) {
+        let module = if input.peek(token::Brace) {
             let content;
             syn::braced!(content in input);
-            let mut doc = None;
+            let mut module = None;
             let fields = Punctuated::<ConfigField, Token![,]>::parse_terminated(&content)?;
             for field in fields.into_pairs() {
                 match field.into_value() {
                     ConfigField::Unchecked => opts.unchecked = true,
                     ConfigField::MultiModule => opts.multi_module = true,
-                    ConfigField::Document(d) => doc = Some(d),
+                    ConfigField::Module(m) => module = Some(m),
                 }
             }
-            doc.ok_or_else(|| Error::new(call_site, "must either specify `src` or `paths` keys"))?
+            module
+                .ok_or_else(|| Error::new(call_site, "must either specify `src` or `paths` keys"))?
         } else {
             let mut paths = Vec::new();
             while !input.is_empty() {
                 let s = input.parse::<syn::LitStr>()?;
                 paths.push(s.value());
             }
-            witx::load(&paths).map_err(|e| Error::new(call_site, e.report()))?
+            if paths.len() == 1 {
+                witx::load(&paths[0]).map_err(|e| Error::new(call_site, e.report()))?
+            } else {
+                return Err(Error::new(
+                    call_site,
+                    "exactly one path is supported right now",
+                ));
+            }
         };
-        Ok(Opts { opts, doc })
+        Ok(Opts { opts, module })
     }
 }
 
 enum ConfigField {
-    Document(witx::Document),
+    Module(witx::Module),
     Unchecked,
     MultiModule,
 }
@@ -76,8 +84,8 @@ impl Parse for ConfigField {
             input.parse::<kw::src>()?;
             input.parse::<Token![:]>()?;
             let s = input.parse::<syn::LitStr>()?;
-            let doc = witx::parse(&s.value()).map_err(|e| Error::new(s.span(), e.report()))?;
-            Ok(ConfigField::Document(doc))
+            let module = witx::parse(&s.value()).map_err(|e| Error::new(s.span(), e.report()))?;
+            Ok(ConfigField::Module(module))
         } else if l.peek(kw::paths) {
             input.parse::<kw::paths>()?;
             input.parse::<Token![:]>()?;
@@ -85,8 +93,15 @@ impl Parse for ConfigField {
             let bracket = syn::bracketed!(paths in input);
             let paths = Punctuated::<syn::LitStr, Token![,]>::parse_terminated(&paths)?;
             let values = paths.iter().map(|s| s.value()).collect::<Vec<_>>();
-            let doc = witx::load(&values).map_err(|e| Error::new(bracket.span, e.report()))?;
-            Ok(ConfigField::Document(doc))
+            if values.len() != 1 {
+                return Err(Error::new(
+                    bracket.span,
+                    "only exactly one path is supported right now",
+                ));
+            }
+            let module =
+                witx::load(&values[0]).map_err(|e| Error::new(bracket.span, e.report()))?;
+            Ok(ConfigField::Module(module))
         } else if l.peek(kw::unchecked) {
             input.parse::<kw::unchecked>()?;
             Ok(ConfigField::Unchecked)

--- a/crates/wasmtime-impl/src/lib.rs
+++ b/crates/wasmtime-impl/src/lib.rs
@@ -15,7 +15,7 @@ pub fn export(input: TokenStream) -> TokenStream {
 fn run(input: TokenStream, import: bool) -> TokenStream {
     let input = syn::parse_macro_input!(input as Opts);
     let mut gen = input.opts.build();
-    let files = gen.generate(&input.doc, import);
+    let files = gen.generate(&input.module, import);
     let (_, contents) = files.iter().next().unwrap();
 
     let mut header = "
@@ -30,7 +30,7 @@ fn run(input: TokenStream, import: bool) -> TokenStream {
 
 struct Opts {
     opts: witx_bindgen_gen_wasmtime::Opts,
-    doc: witx::Document,
+    module: witx::Module,
 }
 
 impl Parse for Opts {
@@ -40,11 +40,18 @@ impl Parse for Opts {
             let s = input.parse::<syn::LitStr>()?;
             paths.push(s.value());
         }
-        let doc = witx::load(&paths)
+        if paths.len() != 1 {
+            let call_site = proc_macro2::Span::call_site();
+            return Err(Error::new(
+                call_site,
+                "only exactly one path is supported right now",
+            ));
+        }
+        let module = witx::load(&paths[0])
             .map_err(|e| Error::new(proc_macro2::Span::call_site(), e.report()))?;
         Ok(Opts {
             opts: Default::default(),
-            doc,
+            module,
         })
     }
 }

--- a/tests/host.witx
+++ b/tests/host.witx
@@ -64,8 +64,11 @@
 (typename $list_typedef2 (list u8))
 (typename $list_typedef3 (list string))
 
-(typename $host_state (handle))
-(typename $host_state2 (handle))
+(resource $host_state_resource)
+(typename $host_state (handle $host_state_resource))
+
+(resource $host_state_resource2)
+(typename $host_state2 (handle $host_state_resource2))
 
 (typename $host_state_param_record (record (field $a $host_state2)))
 (typename $host_state_param_tuple (tuple $host_state2))

--- a/tests/wasm.witx
+++ b/tests/wasm.witx
@@ -41,8 +41,11 @@
 (typename $list_typedef2 (list u8))
 (typename $list_typedef3 (list string))
 
-(typename $wasm_state (handle))
-(typename $wasm_state2 (handle))
+(resource $wasm_state_resource)
+(typename $wasm_state (handle $wasm_state_resource))
+
+(resource $wasm_state_resource2)
+(typename $wasm_state2 (handle $wasm_state_resource2))
 
 (typename $wasm_state_param_record (record (field $a $wasm_state2)))
 (typename $wasm_state_param_tuple (tuple $wasm_state2))


### PR DESCRIPTION
With these changes the tests will run, but fail right now. In the test runner we
do

    let doc = witx::parse(source).unwrap();

and this results in a module whose name is `"-"` which we eventually camel case
and get `""`, and then including this in our emitted Rust source results in
broken Rust code, which causes our tests to fail.

The module name definitely should not be "-" but it is not clear to me yet what
the name *should* be or which bit of code is to blame for this incorrect name.