### PR TITLE
Add "where" as a Rust keyword.

### DIFF
--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -931,6 +931,7 @@ pub fn to_rust_ident(name: &str) -> &str {
     match name {
         "in" => "in_",
         "type" => "type_",
+        "where" => "where_",
         "yield" => "yield_",
         s => s,
     }


### PR DESCRIPTION
I happened to have a parameter named "where" in some experiments I was
doing, so mark it as a Rust keyword so that it's properly escaped.