### PR TITLE
gen-core: Make it so `Files` can hold arbitrary file data

### DIFF
--- a/crates/gen-core/src/lib.rs
+++ b/crates/gen-core/src/lib.rs
@@ -253,22 +253,22 @@ impl Types {
 
 #[derive(Default)]
 pub struct Files {
-    files: BTreeMap<String, String>,
+    files: BTreeMap<String, Vec<u8>>,
 }
 
 impl Files {
-    pub fn push(&mut self, name: &str, contents: &str) {
+    pub fn push(&mut self, name: &str, contents: &[u8]) {
         match self.files.entry(name.to_owned()) {
             Entry::Vacant(entry) => {
                 entry.insert(contents.to_owned());
             }
             Entry::Occupied(ref mut entry) => {
-                entry.get_mut().push_str(contents);
+                entry.get_mut().extend_from_slice(contents);
             }
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&'_ str, &'_ str)> {
-        self.files.iter().map(|p| (p.0.as_str(), p.1.as_str()))
+    pub fn iter(&self) -> impl Iterator<Item = (&'_ str, &'_ [u8])> {
+        self.files.iter().map(|p| (p.0.as_str(), p.1.as_slice()))
     }
 }

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -431,7 +431,7 @@ impl Generator for RustWasm {
             assert!(status.success());
         }
 
-        files.push("bindings.rs", &src);
+        files.push("bindings.rs", src.as_bytes());
     }
 }
 

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -908,7 +908,7 @@ impl Generator for Wasmtime {
             assert!(status.success());
         }
 
-        files.push("bindings.rs", &src);
+        files.push("bindings.rs", src.as_bytes());
     }
 }
 

--- a/crates/rust-wasm-impl/src/lib.rs
+++ b/crates/rust-wasm-impl/src/lib.rs
@@ -22,6 +22,7 @@ fn run(input: TokenStream, import: bool) -> TokenStream {
         gen.generate(&module, import, &mut files);
     }
     let (_, contents) = files.iter().next().unwrap();
+    let contents = std::str::from_utf8(contents).unwrap();
     contents.parse().unwrap()
 }
 

--- a/crates/wasmtime-impl/src/lib.rs
+++ b/crates/wasmtime-impl/src/lib.rs
@@ -26,6 +26,7 @@ fn run(input: TokenStream, import: bool) -> TokenStream {
     "
     .parse::<TokenStream>()
     .unwrap();
+    let contents = std::str::from_utf8(contents).unwrap();
     let contents = contents.parse::<TokenStream>().unwrap();
     header.extend(contents);
     return header;


### PR DESCRIPTION
Not all files are UTF-8 strings. Some can in fact be Wasm files, or arbitrary
binary data, etc... :)