### PR TITLE
Explode `CallMode` into `Direction` and `LiftLower`

### DIFF
--- a/crates/witx2/src/sizealign.rs
+++ b/crates/witx2/src/sizealign.rs
@@ -1,4 +1,4 @@
-use crate::abi::CallMode;
+use crate::abi::Direction;
 use crate::{Int, Interface, Record, RecordKind, Type, TypeDef, TypeDefKind, Variant};
 
 #[derive(Default)]
@@ -7,26 +7,23 @@ pub struct SizeAlign {
 }
 
 impl SizeAlign {
-    pub fn fill(&mut self, mode: CallMode, iface: &Interface) {
+    pub fn fill(&mut self, dir: Direction, iface: &Interface) {
         self.map = vec![(0, 0); iface.types.len()];
         for ty in iface.topological_types() {
-            let pair = self.calculate(mode, &iface.types[ty]);
+            let pair = self.calculate(dir, &iface.types[ty]);
             self.map[ty.index()] = pair;
         }
     }
 
-    fn calculate(&self, mode: CallMode, ty: &TypeDef) -> (usize, usize) {
+    fn calculate(&self, dir: Direction, ty: &TypeDef) -> (usize, usize) {
         match &ty.kind {
             TypeDefKind::Type(t) => (self.size(t), self.align(t)),
             TypeDefKind::List(_) => (8, 4),
             TypeDefKind::Pointer(_) | TypeDefKind::ConstPointer(_) => (4, 4),
-            TypeDefKind::PushBuffer(_) | TypeDefKind::PullBuffer(_) => {
-                if mode.import() {
-                    (12, 4)
-                } else {
-                    (4, 4)
-                }
-            }
+            TypeDefKind::PushBuffer(_) | TypeDefKind::PullBuffer(_) => match dir {
+                Direction::Import => (12, 4),
+                Direction::Export => (4, 4),
+            },
             TypeDefKind::Record(r) => {
                 if let RecordKind::Flags(repr) = r.kind {
                     return match repr {


### PR DESCRIPTION
Often code only cares about whether it is defining an ABI for an import or
export, and doesn't care about whether arguments are lifted and results are
lowered or if arguments are lowered and results are lifted. Often code only
cares about the lifting and lowering, and not whether we are dealing with an
import or an export. These two degrees of freedom were tied together in a single
`CallMode` enum previously. Now they are exploded into two enums:

1. `Direction` for discriminating between import vs export, and
2. `LiftLower` for determining whether we lift arguments and lower results or
   lower arguments and then lift results in this glue code.

Additionally, I hope that the lift/lower nomenclature is more clear than the old
wasm vs native nomenclature, which I personally found quite confusing.