### PR TITLE
Fix endianness and alignment of guest values

### DIFF
--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -369,11 +369,17 @@ impl Generator for Js {
                 let field = field.name.to_shouty_snake_case();
                 self.src.js(&format!(
                     "export const {}_{} = {}{};\n",
-                    name, field, i, suffix,
+                    name,
+                    field,
+                    1u64 << i,
+                    suffix,
                 ));
                 self.src.ts(&format!(
                     "export const {}_{} = {}{};\n",
-                    name, field, i, suffix,
+                    name,
+                    field,
+                    1u64 << i,
+                    suffix,
                 ));
             }
         } else {

--- a/crates/gen-js/tests/run.ts
+++ b/crates/gen-js/tests/run.ts
@@ -239,6 +239,21 @@ function host(): imports.Host {
         r3: [imports.MyErrno.A, imports.MyErrno.B],
       };
     },
+
+    unaligned_roundtrip1(u16, u32, u64, flag32, flag64) {
+      assert.deepStrictEqual(Array.from(u16), [1]);
+      assert.deepStrictEqual(Array.from(u32), [2]);
+      assert.deepStrictEqual(Array.from(u64), [3n]);
+      assert.deepStrictEqual(flag32, [imports.FLAG32_B8]);
+      assert.deepStrictEqual(flag64, [imports.FLAG64_B9]);
+    },
+    unaligned_roundtrip2(record, f32, f64, string, list) {
+      assert.deepStrictEqual(Array.from(record), [{ a: 10, b: 11n, c: 12 }]);
+      assert.deepStrictEqual(Array.from(f32), [100]);
+      assert.deepStrictEqual(Array.from(f64), [101]);
+      assert.deepStrictEqual(string, ['foo']);
+      assert.deepStrictEqual(list, [new Uint8Array([102])]);
+    },
   };
 }
 

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -729,7 +729,10 @@ impl Bindgen for RustWasm {
                     results.push(format!("(flags{} >> {}) as i32", tmp, i * 32));
                 }
             }
-            Instruction::FlagsLower64 { .. } => top_as("i64"),
+            Instruction::FlagsLower64 { .. } => {
+                let s = operands.pop().unwrap();
+                results.push(format!("witx_bindgen_rust::rt::as_i64({})", s));
+            }
             Instruction::FlagsLift { name, .. } | Instruction::FlagsLift64 { name, .. } => {
                 let name = name.to_camel_case();
                 let mut result = String::from("0");

--- a/crates/test-rust-wasm/src/exports.rs
+++ b/crates/test-rust-wasm/src/exports.rs
@@ -7,7 +7,7 @@ witx_bindgen_rust::export!({ paths: ["tests/wasm.witx"], unchecked });
 use wasm::*;
 
 use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
-use witx_bindgen_rust::exports::{InBuffer, InBufferRaw, OutBuffer, OutBufferRaw};
+// use witx_bindgen_rust::exports::{InBuffer, InBufferRaw, OutBuffer, OutBufferRaw};
 
 struct MyWasm {
     scalar: AtomicU32,

--- a/crates/wasmtime/src/le.rs
+++ b/crates/wasmtime/src/le.rs
@@ -1,0 +1,124 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::ptr;
+
+/// Helper type representing a 1-byte-aligned little-endian value in memory.
+///
+/// This type is used in slice types for Wasmtime host bindings. Guest types are
+/// not guaranteed to be either aligned or in the native endianness. This type
+/// wraps these types and provides explicit getters/setters to interact with the
+/// underlying value in a safe host-agnostic manner.
+#[repr(packed)]
+pub struct Le<T>(T);
+
+impl<T> Le<T>
+where
+    T: Endian,
+{
+    /// Creates a new `Le<T>` value where the internals are stored in a way
+    /// that's safe to copy into wasm linear memory.
+    pub fn new(t: T) -> Le<T> {
+        Le(t.into_le())
+    }
+
+    /// Reads the value stored in this `Le<T>`.
+    ///
+    /// This will perform a correct read even if the underlying memory is
+    /// unaligned, and it will also convert to the host's endianness for the
+    /// right representation of `T`.
+    pub fn get(&self) -> T {
+        unsafe { T::read_unaligned_le(ptr::addr_of!(self.0)) }
+    }
+
+    /// Writes the `val` to this slot.
+    ///
+    /// This will work correctly even if the underlying memory is unaligned and
+    /// it will also automatically convert the `val` provided to an endianness
+    /// appropriate for WebAssembly (little-endian).
+    pub fn set(&mut self, val: T) {
+        unsafe { val.write_unaligned_le(ptr::addr_of_mut!(self.0)) }
+    }
+}
+
+impl<T: Copy> Clone for Le<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Copy> Copy for Le<T> {}
+
+impl<T: Endian + PartialEq> PartialEq for Le<T> {
+    fn eq(&self, other: &Le<T>) -> bool {
+        self.get() == other.get()
+    }
+}
+
+impl<T: Endian + Eq> Eq for Le<T> {}
+
+impl<T: Endian + PartialOrd> PartialOrd for Le<T> {
+    fn partial_cmp(&self, other: &Le<T>) -> Option<Ordering> {
+        self.get().partial_cmp(&other.get())
+    }
+}
+
+impl<T: Endian + Ord> Ord for Le<T> {
+    fn cmp(&self, other: &Le<T>) -> Ordering {
+        self.get().cmp(&other.get())
+    }
+}
+
+impl<T: Endian + fmt::Debug> fmt::Debug for Le<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
+impl<T: Endian> From<T> for Le<T> {
+    fn from(t: T) -> Le<T> {
+        Le::new(t)
+    }
+}
+
+/// Trait used for the implementation of the `Le` type.
+pub trait Endian: Copy + Sized {
+    /// Converts this value and any aggregate fields (if any) into little-endian
+    /// byte order
+    fn into_le(self) -> Self;
+    /// Reads a value from the provided possibly-unaligned pointer.
+    /// Converts from little-endian to the host-endianness.
+    unsafe fn read_unaligned_le(ptr: *const Self) -> Self;
+    /// Writes a host-value `self` into `ptr`.
+    ///
+    /// The pointer `ptr` may not be aligned for `Self` and the bytes written
+    /// should also be in little-endian order.
+    unsafe fn write_unaligned_le(self, ptr: *mut Self);
+}
+
+macro_rules! primitives {
+    ($($t:ident)*) => ($(
+        impl Endian for $t {
+            #[inline]
+            fn into_le(self) -> Self {
+                Self::from_le_bytes(self.to_le_bytes())
+            }
+
+            #[inline]
+            unsafe fn read_unaligned_le(ptr: *const Self) -> Self {
+                Self::from_le_bytes(*ptr.cast())
+            }
+
+            #[inline]
+            unsafe fn write_unaligned_le(self, ptr: *mut Self) {
+                *ptr.cast() = self.to_le_bytes();
+            }
+        }
+    )*)
+}
+
+primitives! {
+    u16 i16
+    u32 i32
+    u64 i64
+    f32 f64
+}

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -6,12 +6,14 @@ pub use {anyhow, bitflags, wasmtime};
 mod error;
 pub mod exports;
 pub mod imports;
+mod le;
 mod memory;
 mod ptr;
 mod region;
 mod table;
 
 pub use error::GuestError;
+pub use le::{Endian, Le};
 pub use memory::{BorrowHandle, GuestMemory};
 pub use ptr::{GuestPtr, Pointee};
 pub use region::{BorrowChecker, Region};

--- a/tests/host.witx
+++ b/tests/host.witx
@@ -122,6 +122,11 @@
   (typename $param_in_buffer_bool (in-buffer bool))
   (typename $param_out_buffer_bool (out-buffer bool))
 
+  (typename $unaligned_record (record
+    (field $a u32)
+    (field $b u64)
+  ))
+
   ;; ===========================================
   ;; scalars
   ;; ===========================================
@@ -228,6 +233,20 @@
   (export "list_result3" (func (result $a (list string))))
   (export "string_roundtrip" (func (param $a string) (result $b string)))
 
+  (export "unaligned_roundtrip1" (func
+    (param $a (list u16))
+    (param $b (list u32))
+    (param $c (list u64))
+    (param $d (list $flag32))
+    (param $e (list $flag64))
+  ))
+  (export "unaligned_roundtrip2" (func
+    (param $f (list $unaligned_record))
+    (param $g (list f32))
+    (param $h (list f64))
+    (param $i (list string))
+    (param $j (list (list u8)))
+  ))
 
   ;; ===========================================
   ;; handles


### PR DESCRIPTION
This commit fixes the implementation of Wasmtime imported functions to
stop assuming higher alignment requirements for guest slices.
Additionally it also fixes the wasmtime import functions on big-endian
hosts by automatically converting little-endian values to host-endian values.

I've added tests for alignment but I'm not sure how to add tests for
endianness here. I think we need a big-endian host, but for now let's
just assume it's all correct...

Closes #1