### PR TITLE
Reduce unsafety in wasmtime bindings

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -135,7 +135,9 @@ impl Wasmtime {
                 // might need handle tables later. If we don't end up using
                 // `_tables` that's ok, it'll almost always be optimized away.
                 if self.all_needed_handles.len() > 0 {
-                    self.push_str("let (caller_memory, data) = witx_bindgen_wasmtime::rt::data_and_memory(&mut caller, memory);\n");
+                    self.push_str(
+                        "let (caller_memory, data) = memory.data_and_store_mut(&mut caller);\n",
+                    );
                     self.push_str("let (_, _tables) = get(data);\n");
                 } else {
                     self.push_str("let caller_memory = memory.data_mut(&mut caller);\n");
@@ -575,7 +577,7 @@ impl Generator for Wasmtime {
         if self.needs_borrow_checker {
             self.src.as_mut_string().insert_str(
                 pos,
-                "let (mem, data) = witx_bindgen_wasmtime::rt::data_and_memory(&mut caller, memory);
+                "let (mem, data) = memory.data_and_store_mut(&mut caller);
                 let mut _bc = witx_bindgen_wasmtime::BorrowChecker::new(mem);
                 let host = get(data);\n",
             );

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -112,16 +112,7 @@ impl Wasmtime {
             self.push_str("use witx_bindgen_wasmtime::Le;\n");
         }
         if self.needs_slice_as_bytes {
-            self.push_str(
-                "
-                    unsafe fn slice_as_bytes<T: Copy>(slice: &[T]) -> &[u8] {
-                        core::slice::from_raw_parts(
-                            slice.as_ptr() as *const u8,
-                            core::mem::size_of_val(slice),
-                        )
-                    }
-                ",
-            );
+            self.push_str("use witx_bindgen_wasmtime::rt::slice_as_bytes;\n");
         }
         if self.needs_copy_slice {
             self.push_str("use witx_bindgen_wasmtime::rt::copy_slice;\n");
@@ -1272,7 +1263,7 @@ impl Bindgen for Wasmtime {
                 // the host as in the guest.
                 let mem = self.memory_src();
                 self.push_str(&format!(
-                    "{}.store({}, unsafe {{ slice_as_bytes({}.as_ref()) }})?;\n",
+                    "{}.store({}, slice_as_bytes({}.as_ref()))?;\n",
                     mem, ptr, val
                 ));
                 self.needs_store = true;
@@ -1303,14 +1294,12 @@ impl Bindgen for Wasmtime {
                         self.push_str(&format!("let len{} = {};\n", tmp, operands[1]));
                         let result = format!(
                             "
-                                unsafe {{
-                                    copy_slice(
-                                        &mut caller,
-                                        memory,
-                                        func_{},
-                                        ptr{tmp}, len{tmp}, {}
-                                    )?
-                                }}
+                                copy_slice(
+                                    &mut caller,
+                                    memory,
+                                    func_{},
+                                    ptr{tmp}, len{tmp}, {}
+                                )?
                             ",
                             free,
                             align,

--- a/crates/wasmtime/src/imports.rs
+++ b/crates/wasmtime/src/imports.rs
@@ -18,7 +18,7 @@ impl<'a, T> PullBuffer<'a, T> {
         deserialize: &'a (dyn Fn(&'a [u8]) -> Result<T, Trap> + 'a),
     ) -> Result<PullBuffer<'a, T>, Trap> {
         Ok(PullBuffer {
-            mem: unsafe { mem.slice(offset, len.saturating_mul(size))? },
+            mem: mem.slice(offset, len.saturating_mul(size))?,
             size: size as usize,
             deserialize,
         })
@@ -56,8 +56,7 @@ impl<'a, T> PushBuffer<'a, T> {
         size: i32,
         serialize: &'a (dyn Fn(&mut [u8], T) -> Result<(), Trap> + 'a),
     ) -> Result<PushBuffer<'a, T>, Trap> {
-        let mem =
-            unsafe { mem.slice_mut(offset, (len as u32).saturating_mul(size as u32) as i32)? };
+        let mem = mem.slice_mut(offset, (len as u32).saturating_mul(size as u32) as i32)?;
         Ok(PushBuffer {
             mem,
             size: size as usize,

--- a/crates/wasmtime/src/le.rs
+++ b/crates/wasmtime/src/le.rs
@@ -1,6 +1,6 @@
+use crate::AllBytesValid;
 use std::cmp::Ordering;
 use std::fmt;
-use std::ptr;
 
 /// Helper type representing a 1-byte-aligned little-endian value in memory.
 ///
@@ -27,7 +27,7 @@ where
     /// unaligned, and it will also convert to the host's endianness for the
     /// right representation of `T`.
     pub fn get(&self) -> T {
-        unsafe { T::read_unaligned_le(ptr::addr_of!(self.0)) }
+        self.0.from_le()
     }
 
     /// Writes the `val` to this slot.
@@ -36,7 +36,7 @@ where
     /// it will also automatically convert the `val` provided to an endianness
     /// appropriate for WebAssembly (little-endian).
     pub fn set(&mut self, val: T) {
-        unsafe { val.write_unaligned_le(ptr::addr_of_mut!(self.0)) }
+        self.0 = val.into_le();
     }
 }
 
@@ -80,19 +80,16 @@ impl<T: Endian> From<T> for Le<T> {
     }
 }
 
+unsafe impl<T: AllBytesValid> AllBytesValid for Le<T> {}
+
 /// Trait used for the implementation of the `Le` type.
 pub trait Endian: Copy + Sized {
     /// Converts this value and any aggregate fields (if any) into little-endian
     /// byte order
     fn into_le(self) -> Self;
-    /// Reads a value from the provided possibly-unaligned pointer.
-    /// Converts from little-endian to the host-endianness.
-    unsafe fn read_unaligned_le(ptr: *const Self) -> Self;
-    /// Writes a host-value `self` into `ptr`.
-    ///
-    /// The pointer `ptr` may not be aligned for `Self` and the bytes written
-    /// should also be in little-endian order.
-    unsafe fn write_unaligned_le(self, ptr: *mut Self);
+    /// Converts this value and any aggregate fields (if any) from
+    /// little-endian byte order
+    fn from_le(self) -> Self;
 }
 
 macro_rules! primitives {
@@ -100,17 +97,12 @@ macro_rules! primitives {
         impl Endian for $t {
             #[inline]
             fn into_le(self) -> Self {
-                Self::from_le_bytes(self.to_le_bytes())
+                Self::from_ne_bytes(self.to_le_bytes())
             }
 
             #[inline]
-            unsafe fn read_unaligned_le(ptr: *const Self) -> Self {
-                Self::from_le_bytes(*ptr.cast())
-            }
-
-            #[inline]
-            unsafe fn write_unaligned_le(self, ptr: *mut Self) {
-                *ptr.cast() = self.to_le_bytes();
+            fn from_le(self) -> Self {
+                Self::from_le_bytes(self.to_ne_bytes())
             }
         }
     )*)
@@ -121,4 +113,35 @@ primitives! {
     u32 i32
     u64 i64
     f32 f64
+}
+
+macro_rules! tuples {
+    ($(($($t:ident)*))*) => ($(
+        #[allow(non_snake_case)]
+        impl <$($t:Endian,)*> Endian for ($($t,)*) {
+            fn into_le(self) -> Self {
+                let ($($t,)*) = self;
+                ($($t.into_le(),)*)
+            }
+
+            fn from_le(self) -> Self {
+                let ($($t,)*) = self;
+                ($($t.from_le(),)*)
+            }
+        }
+    )*)
+}
+
+tuples! {
+    ()
+    (T1)
+    (T1 T2)
+    (T1 T2 T3)
+    (T1 T2 T3 T4)
+    (T1 T2 T3 T4 T5)
+    (T1 T2 T3 T4 T5 T6)
+    (T1 T2 T3 T4 T5 T6 T7)
+    (T1 T2 T3 T4 T5 T6 T7 T8)
+    (T1 T2 T3 T4 T5 T6 T7 T8 T9)
+    (T1 T2 T3 T4 T5 T6 T7 T8 T9 T10)
 }

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -12,7 +12,7 @@ mod table;
 
 pub use error::GuestError;
 pub use le::{Endian, Le};
-pub use region::{BorrowChecker, Region};
+pub use region::{AllBytesValid, BorrowChecker, Region};
 pub use table::*;
 
 #[doc(hidden)]

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -80,17 +80,6 @@ pub mod rt {
         }
     }
 
-    pub fn data_and_memory<'a, T>(
-        mut caller: &'a mut Caller<'_, T>,
-        memory: &Memory,
-    ) -> (&'a mut [u8], &'a mut T) {
-        // TODO: comment unsafe
-        unsafe {
-            let memory = &mut *(memory.data_mut(&mut caller) as *mut [u8]);
-            (memory, caller.data_mut())
-        }
-    }
-
     pub fn get_func<T>(caller: &mut Caller<'_, T>, func: &str) -> Result<Func, wasmtime::Trap> {
         let func = caller
             .get_export(func)


### PR DESCRIPTION
This commit removes a number of `unsafe` blocks both in the generated
code as well as internally within the bindings library support. This is
mostly just a refactoring of existing functionality but expressed in a
way that we don't have to write `unsafe` in as many places. Additionally
the `region.rs` tests have been re-enabled where appropriate.