### PR TITLE
Implement an async mode for wasmtime imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ name = "witx-bindgen-wasmtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bitflags",
  "test-build-rust-wasm",
  "thiserror",

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,6 @@
 * Needs more testing on big-endian.
 
 * Features from wiggle:
-  * `async`
   * use `GuestError::InFunc` more liberally
     - stores/loads
     - `try_from` conversions

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -7,7 +7,7 @@ use witx_bindgen_gen_core::witx2::abi::{
     Bindgen, Direction, Instruction, LiftLower, WasmType, WitxInstruction,
 };
 use witx_bindgen_gen_core::{witx2::*, Files, Generator, Source, TypeInfo, Types};
-use witx_bindgen_gen_rust::{int_repr, wasm_type, TypeMode, TypePrint, Visibility};
+use witx_bindgen_gen_rust::{int_repr, wasm_type, Async, TypeMode, TypePrint, Unsafe, Visibility};
 
 #[derive(Default)]
 pub struct RustWasm {
@@ -392,7 +392,12 @@ impl Generator for RustWasm {
             iface,
             func,
             Visibility::Pub,
-            self.is_dtor,
+            if self.is_dtor {
+                Unsafe::Yes
+            } else {
+                Unsafe::No
+            },
+            Async::No,
             None,
             if self.is_dtor {
                 TypeMode::Owned
@@ -466,7 +471,8 @@ impl Generator for RustWasm {
             iface,
             func,
             Visibility::Private,
-            false,
+            Unsafe::No,
+            Async::No,
             Some("&self"),
             if self.is_dtor {
                 TypeMode::Owned

--- a/crates/gen-wasmtime/Cargo.toml
+++ b/crates/gen-wasmtime/Cargo.toml
@@ -15,7 +15,7 @@ heck = "0.3"
 structopt = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
-witx-bindgen-wasmtime = { path = '../wasmtime', features = ['tracing'] }
+witx-bindgen-wasmtime = { path = '../wasmtime', features = ['tracing', 'async'] }
 test-codegen = { path = '../test-codegen', features = ['witx-bindgen-gen-wasmtime'] }
 
 [[test]]

--- a/crates/gen-wasmtime/tests/run.rs
+++ b/crates/gen-wasmtime/tests/run.rs
@@ -41,3 +41,47 @@ mod exports {
         // "!wasm.witx"
     );
 }
+
+mod async_tests {
+    mod not_async {
+        witx_bindgen_wasmtime::import!({
+            src["x"]: "foo: function()",
+            async: ["bar"],
+        });
+
+        struct Me;
+
+        impl x::X for Me {
+            fn foo(&mut self) {}
+        }
+    }
+    mod one_async {
+        witx_bindgen_wasmtime::import!({
+            src["x"]: "
+                foo: function() -> list<u8>
+                bar: function()
+            ",
+            async: ["bar"],
+        });
+
+        struct Me;
+
+        #[witx_bindgen_wasmtime::async_trait]
+        impl x::X for Me {
+            fn foo(&mut self) -> Vec<u8> {
+                Vec::new()
+            }
+
+            async fn bar(&mut self) {}
+        }
+    }
+    mod one_async_export {
+        witx_bindgen_wasmtime::export!({
+            src["x"]: "
+                foo: function(x: list<string>)
+                bar: function()
+            ",
+            async: ["bar"],
+        });
+    }
+}

--- a/crates/test-codegen/src/lib.rs
+++ b/crates/test-codegen/src/lib.rs
@@ -193,6 +193,15 @@ pub fn wasmtime_import(input: TokenStream) -> TokenStream {
                 },
                 |_| quote::quote!(),
             ),
+            (
+                "import-async",
+                || {
+                    let mut opts = witx_bindgen_gen_wasmtime::Opts::default();
+                    opts.async_ = witx_bindgen_gen_wasmtime::Async::All;
+                    opts.build()
+                },
+                |_| quote::quote!(),
+            ),
         ],
     )
 }
@@ -203,11 +212,22 @@ pub fn wasmtime_export(input: TokenStream) -> TokenStream {
     gen_rust(
         input,
         false,
-        &[(
-            "export",
-            || witx_bindgen_gen_wasmtime::Opts::default().build(),
-            |_| quote::quote!(),
-        )],
+        &[
+            (
+                "export",
+                || witx_bindgen_gen_wasmtime::Opts::default().build(),
+                |_| quote::quote!(),
+            ),
+            (
+                "export-async",
+                || {
+                    let mut opts = witx_bindgen_gen_wasmtime::Opts::default();
+                    opts.async_ = witx_bindgen_gen_wasmtime::Async::All;
+                    opts.build()
+                },
+                |_| quote::quote!(),
+            ),
+        ],
     )
 }
 
@@ -332,6 +352,7 @@ fn gen_rust<G: Generator>(
 ) -> TokenStream {
     let mut ret = proc_macro2::TokenStream::new();
     let mut rustfmt = std::process::Command::new("rustfmt");
+    rustfmt.arg("--edition=2018");
     for (name, mk, extra) in tests {
         let tests = generate_tests(input.clone(), name, |_path| (mk(), import));
         let mut sources = proc_macro2::TokenStream::new();

--- a/crates/wasmtime-impl/Cargo.toml
+++ b/crates/wasmtime-impl/Cargo.toml
@@ -18,3 +18,4 @@ witx-bindgen-gen-wasmtime = { path = "../gen-wasmtime", version = "0.1" }
 [features]
 old-witx-compat = ['witx-bindgen-gen-wasmtime/old-witx-compat']
 tracing = []
+async = []

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -11,6 +11,7 @@ thiserror = "1.0"
 wasmtime = { git = 'https://github.com/bytecodealliance/wasmtime', branch = 'main' }
 witx-bindgen-wasmtime-impl = { path = "../wasmtime-impl", version = "0.1" }
 tracing-lib = { version = "0.1.26", optional = true, package = 'tracing' }
+async-trait = { version = "0.1.50", optional = true }
 
 [dev-dependencies]
 wasmtime-wasi = { git = 'https://github.com/bytecodealliance/wasmtime', branch = 'main' }
@@ -23,6 +24,10 @@ default = ['old-witx-compat'] # TODO: rewrite {host,wasm}.witx with new syntax
 # entered and when native functions are called. Note that tracin is currently
 # only done for imported functions.
 tracing = ['tracing-lib', 'witx-bindgen-wasmtime-impl/tracing']
+
+# Enables async support for generated code, although when enabled this still
+# needs to be configured through the macro invocation.
+async = ['async-trait', 'witx-bindgen-wasmtime-impl/async']
 
 # Enables the ability to parse the old s-expression-based `*.witx` format.
 old-witx-compat = ['witx-bindgen-wasmtime-impl/old-witx-compat']

--- a/crates/wasmtime/src/imports.rs
+++ b/crates/wasmtime/src/imports.rs
@@ -6,7 +6,7 @@ use wasmtime::Trap;
 pub struct PullBuffer<'a, T> {
     mem: &'a [u8],
     size: usize,
-    deserialize: &'a (dyn Fn(&'a [u8]) -> Result<T, Trap> + 'a),
+    deserialize: &'a (dyn Fn(&'a [u8]) -> Result<T, Trap> + Send + Sync + 'a),
 }
 
 impl<'a, T> PullBuffer<'a, T> {
@@ -15,7 +15,7 @@ impl<'a, T> PullBuffer<'a, T> {
         offset: i32,
         len: i32,
         size: i32,
-        deserialize: &'a (dyn Fn(&'a [u8]) -> Result<T, Trap> + 'a),
+        deserialize: &'a (dyn Fn(&'a [u8]) -> Result<T, Trap> + Send + Sync + 'a),
     ) -> Result<PullBuffer<'a, T>, Trap> {
         Ok(PullBuffer {
             mem: mem.slice(offset, len.saturating_mul(size))?,
@@ -45,7 +45,7 @@ impl<T> fmt::Debug for PullBuffer<'_, T> {
 pub struct PushBuffer<'a, T> {
     mem: &'a mut [u8],
     size: usize,
-    serialize: &'a (dyn Fn(&mut [u8], T) -> Result<(), Trap> + 'a),
+    serialize: &'a (dyn Fn(&mut [u8], T) -> Result<(), Trap> + Send + Sync + 'a),
 }
 
 impl<'a, T> PushBuffer<'a, T> {
@@ -54,7 +54,7 @@ impl<'a, T> PushBuffer<'a, T> {
         offset: i32,
         len: i32,
         size: i32,
-        serialize: &'a (dyn Fn(&mut [u8], T) -> Result<(), Trap> + 'a),
+        serialize: &'a (dyn Fn(&mut [u8], T) -> Result<(), Trap> + Send + Sync + 'a),
     ) -> Result<PushBuffer<'a, T>, Trap> {
         let mem = mem.slice_mut(offset, (len as u32).saturating_mul(size as u32) as i32)?;
         Ok(PushBuffer {

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -1,5 +1,7 @@
 pub use witx_bindgen_wasmtime_impl::{export, import};
 
+#[cfg(feature = "async")]
+pub use async_trait::async_trait;
 #[cfg(feature = "tracing-lib")]
 pub use tracing_lib as tracing;
 #[doc(hidden)]
@@ -16,6 +18,16 @@ pub use error::GuestError;
 pub use le::{Endian, Le};
 pub use region::{AllBytesValid, BorrowChecker, Region};
 pub use table::*;
+
+pub struct RawMemory {
+    pub slice: *mut [u8],
+}
+
+// This type is threadsafe despite its internal pointer because it allows no
+// safe access to the internal pointer. Consumers must uphold Send/Sync
+// guarantees themselves.
+unsafe impl Send for RawMemory {}
+unsafe impl Sync for RawMemory {}
 
 #[doc(hidden)]
 pub mod rt {

--- a/crates/wasmtime/src/region.rs
+++ b/crates/wasmtime/src/region.rs
@@ -20,6 +20,11 @@ pub struct BorrowChecker<'a> {
     len: usize,
 }
 
+// These are not automatically implemented with our storage of `*mut u8`, so we
+// need to manually declare that this type is threadsafe.
+unsafe impl Send for BorrowChecker<'_> {}
+unsafe impl Sync for BorrowChecker<'_> {}
+
 fn to_trap(err: impl std::error::Error + Send + Sync + 'static) -> Trap {
     Trap::from(Box::new(err) as Box<dyn std::error::Error + Send + Sync>)
 }


### PR DESCRIPTION
This commit implements initial support for async communication with a
wasm module. This implements async support for both calling exports as
well as host-defined imports. The intention of this mode is that
functions can be explicitly configured as either `async` or not, and the
bindings generator will appropriately generate bindings for all functions.

For example if any exported function is asynchronous, then all of them
must be asynchronous because Wasmtime can't mix sync and async calls.
Imports, however, can be mixed-defined as async and sync.

A new test mode was added to ensure that async generation works for all
types. Additionally some wasmtime-specific tests were added about mixing
async/sync calls to ensure that the right bindings are generated.