### PR TITLE
Add per-language configuration to the demo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
     - uses: actions/checkout@v2
     - run: rustup update stable --no-self-update && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - run: npm install
+      working-directory: crates/demo
     - run: ./build-demo.sh
     - uses: JamesIves/github-pages-deploy-action@4.1.4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 static
+package-lock.json
+node_modules
+ace

--- a/build-demo.sh
+++ b/build-demo.sh
@@ -6,11 +6,12 @@ mkdir static
 cargo build -p demo --target wasm32-unknown-unknown --release
 cp target/wasm32-unknown-unknown/release/demo.wasm static/
 
-cargo run -- js --import crates/demo/browser.witx --no-typescript --out-dir static/browser
-cargo run -- js --export crates/demo/demo.witx --no-typescript --out-dir static/demo
+cargo run -- js --import crates/demo/browser.witx --out-dir static/browser
+cargo run -- js --export crates/demo/demo.witx --out-dir static/demo
 
 cp crates/demo/index.html static/
-cp crates/demo/main.js static/
+cp crates/demo/main.ts static/
+(cd crates/demo && npx tsc ../../static/main.ts --target es6)
 
 if [ ! -d ace ]; then
   mkdir ace

--- a/crates/demo/demo.witx
+++ b/crates/demo/demo.witx
@@ -1,13 +1,25 @@
-enum lang {
-  rust,
-  js,
-  wasmtime,
-}
-
 type files = list<tuple<string, string>>
 
-render: function(
+variant async {
+  all,
+  none,
+  only(list<string>),
+}
+
+render_js: function(
   input: string,
-  language: lang,
   import: bool,
+) -> expected<files, string>
+
+render_rust: function(
+  input: string,
+  import: bool,
+  unchecked: bool,
+) -> expected<files, string>
+
+render_wasmtime: function(
+  input: string,
+  import: bool,
+  tracing: bool,
+  async: async,
 ) -> expected<files, string>

--- a/crates/demo/index.html
+++ b/crates/demo/index.html
@@ -23,6 +23,11 @@ body {
 .options {
   margin-bottom: 10px;
 }
+
+.lang-configure {
+  display: none;
+}
+
 </style>
   </head>
   <body>
@@ -30,7 +35,11 @@ body {
         <h1>Input <code>*.witx</code></h1>
         <div class='editor' id='input'></div>
         <textarea id='input-raw' style='display:none'>
-hello: function(name: string) -&gt; string
+record person {
+  name: string,
+  age: u32,
+}
+hello: function(who: person) -&gt; string
 </textarea>
       </div>
       <div class='area'>
@@ -45,6 +54,8 @@ hello: function(name: string) -&gt; string
             <option value="wasmtime">Wasmtime</option>
           </select>
 
+          &middot;
+
           <label for="mode-select">Mode:</label>
 
           <select name="mode" id="mode-select">
@@ -52,9 +63,31 @@ hello: function(name: string) -&gt; string
             <option value="export">export</option>
           </select>
 
+          &middot;
+
           <label for="file-select">File:</label>
           <select name="file" id="file-select">
           </select>
+
+          <div id='configure-js' class='lang-configure'>
+          </div>
+          <div id='configure-rust' class='lang-configure'>
+            &middot;
+
+            <input type="checkbox" id="rust-unchecked" name="unchecked">
+            <label for="rust-unchecked">Unchecked</label>
+          </div>
+          <div id='configure-wasmtime' class='lang-configure'>
+            &middot;
+
+            <input type="checkbox" id="wasmtime-tracing" name="tracing">
+            <label for="wasmtime-tracing"><code>tracing</code></label>
+
+            &middot;
+
+            <input type="checkbox" id="wasmtime-async" name="async">
+            <label for="wasmtime-async"><code>async</code></label>
+          </div>
         </div>
 
         <div class='editor' id='output'></div>

--- a/crates/demo/package.json
+++ b/crates/demo/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@types/ace": "^0.0.46",
+    "typescript": "^4.3.4"
+  }
+}

--- a/crates/gen-js/.gitignore
+++ b/crates/gen-js/.gitignore
@@ -1,2 +1,0 @@
-node_modules
-package-lock.json

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -296,7 +296,7 @@ impl Js {
             if i > 0 {
                 self.src.ts(", ");
             }
-            self.src.ts(&name.to_snake_case());
+            self.src.ts(to_js_ident(&name.to_snake_case()));
             self.src.ts(": ");
             self.print_ty(iface, ty);
         }
@@ -1822,6 +1822,14 @@ impl Js {
                 }
             ");
         }
+    }
+}
+
+pub fn to_js_ident(name: &str) -> &str {
+    match name {
+        "in" => "in_",
+        "import" => "import_",
+        s => s,
     }
 }
 

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -1062,6 +1062,7 @@ pub fn to_rust_ident(name: &str) -> &str {
         "type" => "type_",
         "where" => "where_",
         "yield" => "yield_",
+        "async" => "async_",
         s => s,
     }
 }

--- a/crates/wasmtime-impl/src/lib.rs
+++ b/crates/wasmtime-impl/src/lib.rs
@@ -32,12 +32,28 @@ fn run(input: TokenStream, import: bool) -> TokenStream {
     let contents = std::str::from_utf8(contents).unwrap();
     let contents = contents.parse::<TokenStream>().unwrap();
     header.extend(contents);
+
+    // Include a dummy `include_str!` for any files we read so rustc knows that
+    // we depend on the contents of those files.
+    let cwd = std::env::current_dir().unwrap();
+    for file in input.files.iter() {
+        header.extend(
+            format!(
+                "const _: &str = include_str!(\"{}\");\n",
+                cwd.join(file).display()
+            )
+            .parse::<TokenStream>()
+            .unwrap(),
+        );
+    }
+
     return header;
 }
 
 struct Opts {
     opts: witx_bindgen_gen_wasmtime::Opts,
     interfaces: Vec<witx2::Interface>,
+    files: Vec<String>,
 }
 
 mod kw {
@@ -49,6 +65,7 @@ impl Parse for Opts {
     fn parse(input: ParseStream<'_>) -> Result<Opts> {
         let call_site = proc_macro2::Span::call_site();
         let mut opts = witx_bindgen_gen_wasmtime::Opts::default();
+        let mut files = Vec::new();
         opts.tracing = cfg!(feature = "tracing");
 
         let interfaces = if input.peek(token::Brace) {
@@ -70,20 +87,23 @@ impl Parse for Opts {
             }
             interfaces
         } else {
-            let mut paths = Vec::new();
             while !input.is_empty() {
                 let s = input.parse::<syn::LitStr>()?;
-                paths.push(s.value());
+                files.push(s.value());
             }
             let mut interfaces = Vec::new();
-            for path in &paths {
+            for path in files.iter() {
                 let iface =
-                    witx2::Interface::parse_file(&path).map_err(|e| Error::new(call_site, e))?;
+                    witx2::Interface::parse_file(path).map_err(|e| Error::new(call_site, e))?;
                 interfaces.push(iface);
             }
             interfaces
         };
-        Ok(Opts { opts, interfaces })
+        Ok(Opts {
+            opts,
+            interfaces,
+            files,
+        })
     }
 }
 


### PR DESCRIPTION
Also fix a number of issues while I'm at it:

* Rust macros use `include_str!` to depend on the input `*.witx` files
* Fix variables of the name `async` in Rust
* Fix variables of the name `import` in JS
* Move the demo to TypeScript to be more resilient to witx changes
* Spice up the default demo slightlyj