### PR TITLE
Support custom error types in Wasmtime

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,9 +6,6 @@
 
 # wasmtime
 
-* Functions need to be able to at least optionally return a trap, e.g.
-  `proc_raise` or they were passed an invalid buffer.
-
 * buffer-in-buffer doesn't work. Doesn't work because we can't get a re-access
   of the transaction to add more buffers into it after-the-fact.
 
@@ -18,10 +15,6 @@
   * use `GuestError::InFunc` more liberally
     - stores/loads
     - `try_from` conversions
-  * user-defined conversion from user-defined type to the actual type
-    - used for converting `anyhow::Error` into either an errno or a trap
-    - check for specific type of error, otherwise assume trap
-    - conversion receives context to optionally store the error message
   * generate just the trait (??? what to do about `wasmtime` dep ???)
 
 # JS

--- a/crates/demo/demo.witx
+++ b/crates/demo/demo.witx
@@ -22,4 +22,5 @@ render_wasmtime: function(
   import: bool,
   tracing: bool,
   async: async,
+  custom_error: bool,
 ) -> expected<files, string>

--- a/crates/demo/index.html
+++ b/crates/demo/index.html
@@ -87,6 +87,11 @@ hello: function(who: person) -&gt; string
 
             <input type="checkbox" id="wasmtime-async" name="async">
             <label for="wasmtime-async"><code>async</code></label>
+
+            &middot;
+
+            <input type="checkbox" id="wasmtime-custom-error" name="custom-error">
+            <label for="wasmtime-custom-error">custom error</label>
           </div>
         </div>
 

--- a/crates/demo/main.ts
+++ b/crates/demo/main.ts
@@ -21,6 +21,7 @@ const files = document.getElementById('file-select') as HTMLSelectElement;
 const rustUnchecked = document.getElementById('rust-unchecked') as HTMLInputElement;
 const wasmtimeTracing = document.getElementById('wasmtime-tracing') as HTMLInputElement;
 const wasmtimeAsync = document.getElementById('wasmtime-async') as HTMLInputElement;
+const wasmtimeCustomError = document.getElementById('wasmtime-custom-error') as HTMLInputElement;
 
 const inputEditor = ace.edit("input");
 const outputEditor = ace.edit("output");
@@ -58,7 +59,13 @@ async function render() {
         async_ = { tag: 'all' };
       else
         async_ = { tag: 'none' };
-      result = wasm.render_wasmtime(witx, is_import, wasmtimeTracing.checked, async_);
+      result = wasm.render_wasmtime(
+        witx,
+        is_import,
+        wasmtimeTracing.checked,
+        async_,
+        wasmtimeCustomError.checked,
+      );
       break;
     default: return;
   }
@@ -109,6 +116,7 @@ mode.addEventListener('change', render);
 rustUnchecked.addEventListener('change', render);
 wasmtimeTracing.addEventListener('change', render);
 wasmtimeAsync.addEventListener('change', render);
+wasmtimeCustomError.addEventListener('change', render);
 files.addEventListener('change', updateSelectedFile);
 
 

--- a/crates/demo/src/lib.rs
+++ b/crates/demo/src/lib.rs
@@ -67,6 +67,7 @@ impl demo::Demo for Demo {
         import: bool,
         tracing: bool,
         async_: demo::Async,
+        custom_error: bool,
     ) -> Result<Vec<(String, String)>, String> {
         use witx_bindgen_gen_wasmtime::Async;
 
@@ -77,6 +78,7 @@ impl demo::Demo for Demo {
             demo::Async::None => Async::None,
             demo::Async::Only(list) => Async::Only(list.into_iter().collect()),
         };
+        opts.custom_error = custom_error;
         self.generate(&witx, import, opts.build())
     }
 }

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -565,20 +565,20 @@ pub trait RustGenerator {
                 self.push_str("{\n");
 
                 self.push_str("pub fn name(&self) -> &'static str {\n");
-                self.push_str("match self {");
+                self.push_str("match self {\n");
                 for case in variant.cases.iter() {
                     self.push_str(&name);
                     self.push_str("::");
                     self.push_str(&case_name(&case.name));
                     self.push_str(" => \"");
                     self.push_str(case.name.as_str());
-                    self.push_str("\",");
+                    self.push_str("\",\n");
                 }
                 self.push_str("}\n");
                 self.push_str("}\n");
 
                 self.push_str("pub fn message(&self) -> &'static str {\n");
-                self.push_str("match self {");
+                self.push_str("match self {\n");
                 for case in variant.cases.iter() {
                     self.push_str(&name);
                     self.push_str("::");
@@ -587,7 +587,7 @@ pub trait RustGenerator {
                     if let Some(contents) = &case.docs.contents {
                         self.push_str(contents.trim());
                     }
-                    self.push_str("\",");
+                    self.push_str("\",\n");
                 }
                 self.push_str("}\n");
                 self.push_str("}\n");
@@ -601,11 +601,11 @@ pub trait RustGenerator {
                 );
                 self.push_str("f.debug_struct(\"");
                 self.push_str(&name);
-                self.push_str("\")");
-                self.push_str(".field(\"code\", &(*self as i32))");
-                self.push_str(".field(\"name\", &self.name())");
-                self.push_str(".field(\"message\", &self.message())");
-                self.push_str(".finish()");
+                self.push_str("\")\n");
+                self.push_str(".field(\"code\", &(*self as i32))\n");
+                self.push_str(".field(\"name\", &self.name())\n");
+                self.push_str(".field(\"message\", &self.message())\n");
+                self.push_str(".finish()\n");
                 self.push_str("}\n");
                 self.push_str("}\n");
 

--- a/crates/gen-wasmtime/tests/run.rs
+++ b/crates/gen-wasmtime/tests/run.rs
@@ -85,3 +85,18 @@ mod async_tests {
         });
     }
 }
+
+mod custom_errors {
+    witx_bindgen_wasmtime::import!({
+        src["x"]: "
+            foo: function()
+            bar: function() -> expected<_, u32>
+            enum errno {
+                bad1,
+                bad2,
+            }
+            baz: function() -> expected<u32, errno>
+        ",
+        custom_error: true,
+    });
+}

--- a/crates/test-codegen/src/lib.rs
+++ b/crates/test-codegen/src/lib.rs
@@ -186,10 +186,11 @@ pub fn wasmtime_import(input: TokenStream) -> TokenStream {
                 |_| quote::quote!(),
             ),
             (
-                "import-tracing",
+                "import-tracing-and-custom-error",
                 || {
                     let mut opts = witx_bindgen_gen_wasmtime::Opts::default();
                     opts.tracing = true;
+                    opts.custom_error = true;
                     opts.build()
                 },
                 |_| quote::quote!(),

--- a/crates/wasmtime-impl/src/lib.rs
+++ b/crates/wasmtime-impl/src/lib.rs
@@ -60,6 +60,7 @@ struct Opts {
 mod kw {
     syn::custom_keyword!(src);
     syn::custom_keyword!(paths);
+    syn::custom_keyword!(custom_error);
 }
 
 impl Parse for Opts {
@@ -78,6 +79,7 @@ impl Parse for Opts {
                 match field.into_value() {
                     ConfigField::Interfaces(v) => interfaces = v,
                     ConfigField::Async(v) => opts.async_ = v,
+                    ConfigField::CustomError(v) => opts.custom_error = v,
                 }
             }
             if interfaces.is_empty() {
@@ -111,6 +113,7 @@ impl Parse for Opts {
 enum ConfigField {
     Interfaces(Vec<witx2::Interface>),
     Async(witx_bindgen_gen_wasmtime::Async),
+    CustomError(bool),
 }
 
 impl Parse for ConfigField {
@@ -158,6 +161,12 @@ impl Parse for ConfigField {
                 Async::Only(values)
             };
             Ok(ConfigField::Async(val))
+        } else if l.peek(kw::custom_error) {
+            input.parse::<kw::custom_error>()?;
+            input.parse::<Token![:]>()?;
+            Ok(ConfigField::CustomError(
+                input.parse::<syn::LitBool>()?.value,
+            ))
         } else {
             Err(l.error())
         }


### PR DESCRIPTION
This adds support for a configuration value for Wasmtime where all
Rust-defined methods will return a `Result` with a custom error, and
then the trait has conversion methods from this error payload back to
either a `Trap` to propagate or the original error value if applicable.