### PR TITLE
Assign explicit values to TS enums

### DIFF
--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -347,10 +347,10 @@ impl Generator for Js {
         } else if variant.is_enum() {
             self.src
                 .ts(&format!("export enum {} {{\n", name.to_camel_case()));
-            for case in variant.cases.iter() {
+            for (i, case) in variant.cases.iter().enumerate() {
                 self.docs(&case.docs);
-                self.src.ts(&case.name.to_camel_case());
-                self.src.ts(",\n");
+                let name = case.name.to_camel_case();
+                self.src.ts(&format!("{} = {},\n", name, i));
             }
             self.src.ts("}\n");
 

--- a/crates/gen-js/tests/run.ts
+++ b/crates/gen-js/tests/run.ts
@@ -371,6 +371,11 @@ function test_variants(wasm: exports.Wasm) {
   assert.deepStrictEqual(wasm.invert_bool(false), true);
 
   {
+    const a: exports.E1.A = exports.E1.A;
+    const b: exports.E1.B = exports.E1.B;
+  }
+
+  {
     const [a1, a2, a3, a4, a5, a6] = wasm.variant_casts([
       { tag: 'a', val: 1 },
       { tag: 'a', val: 2 },


### PR DESCRIPTION
Generated TypeScript enum definitions are currently difficult to use because they lack explicitly assigned values.

For example, the following TypeScript code currently does not compile without this change:

#### generated .d.ts declaration
```ts
export enum Foo {
  Bar,
  Baz,
}
```
#### .ts script
```ts
interface MyInterface {
  tag: Foo.Bar, // error: Enum type 'Foo' has members with initializers that are not literals.
  value: number,
}
```

This change would add values to the enum definitions:

```ts
export enum Foo {
  Bar = 0,
  Baz = 1,
}
```

I am not well-acquainted with TypeScript so maybe there's a better way to fix this.