### PR TITLE
Reimplement exported resources

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,3 +51,10 @@
 
 * Enums are handled in lowering as either strings or numbers, but should only
   numbers be handled here? Does anyone pass around strings as enum values?
+
+* Exported handle types in JS aren't nominal. As of this writing they all only
+  have a `drop` and a `clone` method so they're interchangeable from `tsc`'s
+  perspective. Ideally these would be nominal separate types.
+
+* Imported handle types show up as `any` in TS, unsure how to plumb through
+  actual types to get that actually typed.

--- a/crates/demo/demo.witx
+++ b/crates/demo/demo.witx
@@ -6,21 +6,20 @@ variant async {
   only(list<string>),
 }
 
-render_js: function(
-  input: string,
-  import: bool,
-) -> expected<files, string>
+enum lang {
+  js,
+  rust,
+  wasmtime,
+}
 
-render_rust: function(
-  input: string,
-  import: bool,
-  unchecked: bool,
-) -> expected<files, string>
 
-render_wasmtime: function(
-  input: string,
-  import: bool,
-  tracing: bool,
-  async: async,
-  custom_error: bool,
-) -> expected<files, string>
+resource config
+
+config_new: function() -> config
+
+render: function(c: config, lang: lang, witx: string, import: bool) -> expected<files, string>
+
+set_rust_unchecked: function(c: config, unchecked: bool)
+set_wasmtime_tracing: function(c: config, unchecked: bool)
+set_wasmtime_async: function(c: config, async: async)
+set_wasmtime_custom_error: function(c: config, custom: bool)

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -9,6 +9,7 @@ use witx_bindgen_gen_core::{witx2::*, Files, Generator};
 #[derive(Default)]
 pub struct Js {
     src: Source,
+    in_import: bool,
     opts: Opts,
     imports: HashMap<String, Vec<Import>>,
     exports: HashMap<String, Exports>,
@@ -28,7 +29,8 @@ pub struct Js {
     needs_f64_to_i64: bool,
     needs_utf8_decoder: bool,
     needs_utf8_encode: bool,
-    needed_resources: BTreeSet<ResourceId>,
+    imported_resources: BTreeSet<ResourceId>,
+    exported_resources: BTreeSet<ResourceId>,
     needs_validate_flags: bool,
     needs_validate_flags64: bool,
     needs_push_buffer: bool,
@@ -117,7 +119,14 @@ impl Js {
             | Type::F64 => self.src.ts("number"),
             Type::U64 | Type::S64 => self.src.ts("bigint"),
             Type::Char => self.src.ts("string"),
-            Type::Handle(_) => self.src.ts("any"), // TODO
+            // For imports handles represent host objects, so any host object
+            // can be provided
+            //
+            // TODO: we still have distinct types of handles and this shouldn't
+            // be `any`, that loses more type information than I'd like.
+            Type::Handle(_) if self.in_import => self.src.ts("any"),
+            // For exports handles are specific types of exports
+            Type::Handle(id) => self.src.ts(&iface.resources[*id].name.to_camel_case()),
             Type::Id(id) => {
                 let ty = &iface.types[*id];
                 if let Some(name) = &ty.name {
@@ -265,6 +274,7 @@ impl Js {
 impl Generator for Js {
     fn preprocess(&mut self, iface: &Interface, dir: Direction) {
         self.sizes.fill(dir, iface);
+        self.in_import = dir == Direction::Import;
     }
 
     fn type_record(
@@ -395,8 +405,73 @@ impl Generator for Js {
     }
 
     fn type_resource(&mut self, iface: &Interface, ty: ResourceId) {
-        // panic!()
-        drop((iface, ty));
+        if self.in_import {
+            return;
+        }
+        self.exported_resources.insert(ty);
+        self.src.js(&format!(
+            "
+                export class {} {{
+                    constructor(wasm_val, dtor, registry) {{
+                        this._wasm_val = wasm_val;
+                        this._registry = registry;
+                        this._dtor = dtor;
+                        this._refcnt = 1;
+                        registry.register(this, wasm_val, this);
+                    }}
+
+                    clone() {{
+                        this._refcnt += 1;
+                        return this;
+                    }}
+
+                    drop() {{
+                        this._refcnt -= 1;
+                        if (this._refcnt !== 0)
+                            return;
+                        this._registry.unregister(this);
+                        const dtor = this._dtor;
+                        const wasm_val = this._wasm_val;
+                        delete this._dtor;
+                        delete this._refcnt;
+                        delete this._registry;
+                        delete this._wasm_val;
+                        dtor(wasm_val);
+                    }}
+                }}
+            ",
+            iface.resources[ty].name.to_camel_case(),
+        ));
+        self.src.ts(&format!(
+            "
+                export class {} {{
+                    // Creates a new strong reference count as a new object.
+                    // This is only required if you're also calling `drop`
+                    // below and want to manually manage the reference count
+                    // from JS.
+                    //
+                    // If you don't call `drop`, you don't need to call this
+                    // and can simply use the object from JS.
+                    clone(): {0};
+
+                    // Explicitly indicate that this JS object will no longer
+                    // be used. If the internal reference count reaches zero
+                    // then this will deterministically destroy the underlying
+                    // wasm object.
+                    //
+                    // This is not required to be called from JS. Wasm
+                    // destructors will be automatically called for you if
+                    // this is not called using the JS `FinalizationRegistry`.
+                    //
+                    // Calling this method does not guarantee that the
+                    // underlying wasm object is deallocated. Something else
+                    // (including wasm) may be holding onto a strong reference
+                    // count.
+                    drop(): void;
+                }}
+            ",
+            iface.resources[ty].name.to_camel_case(),
+        ));
     }
 
     fn type_alias(&mut self, iface: &Interface, _id: TypeId, name: &str, ty: &Type, docs: &Docs) {
@@ -618,11 +693,11 @@ impl Generator for Js {
                 self.src.ts(&f.src.ts);
             }
 
-            if self.needed_resources.len() > 0 {
+            if self.imported_resources.len() > 0 {
                 self.src
                     .js("if (!(\"canonical_abi\" in imports)) imports[\"canonical_abi\"] = {};\n");
             }
-            for resource in self.needed_resources.iter() {
+            for resource in self.imported_resources.iter() {
                 self.src.js(&format!(
                     "imports.canonical_abi[\"resource_drop_{}\"] = (i) => {{
                         const val = resources{}.remove(i);
@@ -644,44 +719,156 @@ impl Generator for Js {
 
         for (module, exports) in mem::take(&mut self.exports) {
             let module = module.to_camel_case();
-            // TODO: `module.exports` vs `export function`
+            self.src.ts(&format!("export class {} {{\n", module));
             self.src.js(&format!("export class {} {{\n", module));
 
-            self.src.js("static async instantiate(module, imports) {\n");
-            self.src.js(&format!("const me = new {}();\n", module));
-            self.src.js("
-                let ret;
-                if (module instanceof WebAssembly.Module) {
-                    ret = {
-                        module,
-                        instance: await WebAssembly.instantiate(module, imports),
-                    };
-                } else if (module instanceof ArrayBuffer || module instanceof Uint8Array) {
-                    ret = await WebAssembly.instantiate(module, imports);
-                } else {
-                    ret = await WebAssembly.instantiateStreaming(module, imports);
-                }
-                me.module = ret.module;
-                me.instance = ret.instance;
-                me._exports = me.instance.exports;
-                return me;
+            self.src.ts("
+                // The WebAssembly instance that this class is operating with.
+                // This is only available after the `instantiate` method has
+                // been called.
+                instance: WebAssembly.Instance;
             ");
+
+            self.src.ts("
+                // Constructs a new instance with internal state necessary to
+                // manage a wasm instance.
+                //
+                // Note that this does not actually instantiate the WebAssembly
+                // instance or module, you'll need to call the `instantiate`
+                // method below to \"activate\" this class.
+                constructor();
+            ");
+            if self.exported_resources.len() > 0 {
+                self.src.js("constructor() {\n");
+                for r in self.exported_resources.iter() {
+                    self.src
+                        .js(&format!("this._resource{}_slab = new Slab();\n", r.index()));
+                }
+                self.src.js("}\n");
+            }
+
+            self.src.ts("
+                // This is a low-level method which can be used to add any
+                // intrinsics necessary for this instance to operate to an
+                // import object.
+                //
+                // The `import` object given here is expected to be used later
+                // to actually instantiate the module this class corresponds to.
+                // If the `instantiate` method below actually does the
+                // instantiation then there's no need to call this method, but
+                // if you're instantiating manually elsewhere then this can be
+                // used to prepare the import object for external instantiation.
+                add_to_imports(imports: any);
+            ");
+            self.src.js("add_to_imports(imports) {\n");
+            if self.exported_resources.len() > 0 {
+                self.src
+                    .js("if (!(\"canonical_abi\" in imports)) imports[\"canonical_abi\"] = {};\n");
+            }
+            for r in self.exported_resources.iter() {
+                self.src.js(&format!(
+                    "
+                        imports.canonical_abi['resource_drop_{name}'] = i => {{
+                            this._resource{idx}_slab.remove(i).drop();
+                        }};
+                        imports.canonical_abi['resource_clone_{name}'] = i => {{
+                            const obj = this._resource{idx}_slab.get(i);
+                            return this._resource{idx}_slab.insert(obj.clone())
+                        }};
+                        imports.canonical_abi['resource_get_{name}'] = i => {{
+                            return this._resource{idx}_slab.get(i)._wasm_val;
+                        }};
+                        imports.canonical_abi['resource_new_{name}'] = i => {{
+                            const dtor = this._exports['canonical_abi_drop_{name}'];
+                            const registry = this._registry{idx};
+                            return this._resource{idx}_slab.insert(new {class}(i, dtor, registry));
+                        }};
+                    ",
+                    name = iface.resources[*r].name,
+                    idx = r.index(),
+                    class = iface.resources[*r].name.to_camel_case(),
+                ));
+            }
             self.src.js("}\n");
 
-            self.src.ts(&format!("export class {} {{\n", module));
             self.src.ts(&format!(
-                "static instantiate(module: WebAssembly.Module | BufferSource | Promise<Response> | Response, imports: any): Promise<{}>;\n",
-                module
+                "
+                    // Initializes this object with the provided WebAssembly
+                    // module/instance.
+                    //
+                    // This is intended to be a flexible method of instantiating
+                    // and completion of the initialization of this class. This
+                    // method must be called before interacting with the
+                    // WebAssembly object.
+                    //
+                    // The first argument to this method is where to get the
+                    // wasm from. This can be a whole bunch of different types,
+                    // for example:
+                    //
+                    // * A precompiled `WebAssembly.Module`
+                    // * A typed array buffer containing the wasm bytecode.
+                    // * A `Promise` of a `Response` which is used with
+                    //   `instantiateStreaming`
+                    // * A `Response` itself used with `instantiateStreaming`.
+                    // * An already instantiated `WebAssembly.Instance`
+                    //
+                    // If necessary the module is compiled, and if necessary the
+                    // module is instantiated. Whether or not it's necessary
+                    // depends on the type of argument provided to
+                    // instantiation.
+                    //
+                    // If instantiation is performed then the `imports` object
+                    // passed here is the list of imports used to instantiate
+                    // the instance. This method may add its own intrinsics to
+                    // this `imports` object too.
+                    instantiate(
+                        module: WebAssembly.Module | BufferSource | Promise<Response> | Response | WebAssembly.Instance,
+                        imports?: any,
+                    ): Promise<void>;
+                ",
             ));
-            self.src.ts("instance: WebAssembly.Instance;\n");
-            self.src.ts("module: WebAssembly.Module;\n");
+            self.src.js("
+                async instantiate(module, imports) {
+                    imports = imports || {};
+                    this.add_to_imports(imports);
+            ");
+
+            // With intrinsics prep'd we can now instantiate the module. JS has
+            // a ... variety of methods of instantiation, so we basically just
+            // try to be flexible here.
+            self.src.js("
+                if (module instanceof WebAssembly.Instance) {
+                    this.instance = module;
+                } else if (module instanceof WebAssembly.Module) {
+                    this.instance = await WebAssembly.instantiate(module, imports);
+                } else if (module instanceof ArrayBuffer || module instanceof Uint8Array) {
+                    const { instance } = await WebAssembly.instantiate(module, imports);
+                    this.instance = instance;
+                } else {
+                    const { instance } = await WebAssembly.instantiateStreaming(module, imports);
+                    this.instance = instance;
+                }
+                this._exports = this.instance.exports;
+            ");
+
+            // Exported resources all get a finalization registry, and we
+            // created them after instantiation so we can pass the raw wasm
+            // export as the destructor callback.
+            for r in self.exported_resources.iter() {
+                self.src.js(&format!(
+                    "this._registry{} = new FinalizationRegistry(this._exports['canonical_abi_drop_{}']);\n",
+                    r.index(),
+                    iface.resources[*r].name,
+                ));
+            }
+            self.src.js("}\n");
 
             for func in exports.funcs.iter() {
                 self.src.js(&func.js);
                 self.src.ts(&func.ts);
             }
             self.src.ts("}\n");
-            self.src.js("}");
+            self.src.js("}\n");
         }
 
         files.push("bindings.js", self.src.js.as_bytes());
@@ -918,26 +1105,48 @@ impl Bindgen for FunctionBindgen<'_> {
                 }
             }
 
+            // These instructions are used with handles when we're implementing
+            // imports. This means we interact with the `resources` slabs to
+            // translate the wasm-provided index into a JS value.
             Instruction::I32FromOwnedHandle { ty } => {
-                self.gen.needed_resources.insert(*ty);
+                self.gen.imported_resources.insert(*ty);
                 results.push(format!("resources{}.insert({})", ty.index(), operands[0]));
             }
             Instruction::HandleBorrowedFromI32 { ty } => {
-                self.gen.needed_resources.insert(*ty);
+                self.gen.imported_resources.insert(*ty);
                 results.push(format!("resources{}.get({})", ty.index(), operands[0]));
             }
-            //    Instruction::I32FromBorrowedHandle { .. } => {
-            //        results.push(format!("{}.0", operands[0]));
-            //    }
-            //    Instruction::HandleOwnedFromI32 { ty } => {
-            //        let name = &iface.resources[*ty].name;
-            //        results.push(format!(
-            //            "{}({}, std::mem::ManuallyDrop::new(self.{}_close.clone()))",
-            //            name.to_camel_case(),
-            //            operands[0],
-            //            name.to_snake_case(),
-            //        ));
-            //    }
+
+            // These instructions are used for handles to objects owned in wasm.
+            // This means that they're interacting with a wrapper class defined
+            // in JS.
+            Instruction::I32FromBorrowedHandle { ty } => {
+                let tmp = self.tmp();
+                self.src
+                    .js(&format!("const obj{} = {};\n", tmp, operands[0]));
+                self.src.js(&format!(
+                    "if (!(obj{} instanceof {})) ",
+                    tmp,
+                    iface.resources[*ty].name.to_camel_case()
+                ));
+                self.src.js(&format!(
+                    "throw new TypeError('expected instance of {}');\n",
+                    iface.resources[*ty].name.to_camel_case()
+                ));
+                results.push(format!(
+                    "this._resource{}_slab.insert(obj{}.clone())",
+                    ty.index(),
+                    tmp,
+                ));
+            }
+            Instruction::HandleOwnedFromI32 { ty } => {
+                results.push(format!(
+                    "this._resource{}_slab.remove({})",
+                    ty.index(),
+                    operands[0],
+                ));
+            }
+
             Instruction::RecordLower { record, .. } => {
                 if record.is_tuple() {
                     // Tuples are represented as an array, sowe can use
@@ -1689,7 +1898,7 @@ impl Js {
             ");
         }
 
-        if self.needed_resources.len() > 0 {
+        if self.imported_resources.len() > 0 || self.exported_resources.len() > 0 {
             self.src.js("
                 class Slab {
                     constructor() {
@@ -1733,7 +1942,7 @@ impl Js {
                 }
             ");
         }
-        for r in self.needed_resources.iter() {
+        for r in self.imported_resources.iter() {
             self.src
                 .js(&format!("const resources{} = new Slab();\n", r.index()));
         }

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -51,7 +51,7 @@ struct Exports {
     funcs: Vec<Source>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
 pub struct Opts {
     #[cfg_attr(feature = "structopt", structopt(long = "no-typescript"))]

--- a/crates/gen-js/tests/eslint.rs
+++ b/crates/gen-js/tests/eslint.rs
@@ -32,15 +32,9 @@ mod exports {
         "!typenames.witx"
         "!wasi_snapshot_preview1.witx"
 
-        // This uses handles, which we don't support in exports just yet
+        // This uses buffers, which we don't support in exports just yet
         // TODO: should support this
-        "!wasi_types.witx"
         "!wasi_next.witx"
-
-        // If you want to exclude other test you can include it here with
-        // gitignore glob syntax:
-        //
-        // "!wasm.witx"
     );
 }
 fn main() {

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -22,6 +22,7 @@ pub struct RustWasm {
     trait_name: String,
     i64_return_pointer_area_size: usize,
     sizes: SizeAlign,
+    imported_handles: BTreeSet<String>,
 }
 
 #[derive(Default, Debug)]
@@ -49,7 +50,6 @@ pub struct Opts {
 #[derive(Default)]
 struct Trait {
     methods: Vec<String>,
-    handles: BTreeSet<String>,
 }
 
 impl Opts {
@@ -74,23 +74,21 @@ impl RustGenerator for RustWasm {
             // to allocate anything.
             TypeMode::AllBorrowed("'a")
         } else {
-            // When we're exporting items that means that all our arguments come
-            // from somewhere else so everything is owned, namely lists.
-            TypeMode::HandlesBorrowed("'a")
+            // In exports everythig is always owned, slices and handles and all.
+            // Nothing is borrowed.
+            TypeMode::Owned
         }
     }
 
     fn handle_projection(&self) -> Option<(&'static str, String)> {
+        None
+    }
+
+    fn handle_wrapper(&self) -> Option<&'static str> {
         if self.in_import {
-            // All handles are defined types when we're importing them
             None
         } else {
-            // Handles for exports are associated types on the trait.
-            if self.in_trait {
-                Some(("Self", self.trait_name.clone()))
-            } else {
-                Some(("T", self.trait_name.clone()))
-            }
+            Some("witx_bindgen_rust::Handle")
         }
     }
 
@@ -260,11 +258,86 @@ impl Generator for RustWasm {
     }
 
     fn type_resource(&mut self, iface: &Interface, ty: ResourceId) {
-        // If we're generating types for an exported handle then no type is
-        // generated since this type is provided by the the generated trait.
+        // For exported handles we synthesize some trait implementations
+        // automatically for runtime-required traits.
         if !self.in_import {
+            self.src.push_str(&format!(
+                "
+                    unsafe impl witx_bindgen_rust::HandleType for super::{ty} {{
+                        #[inline]
+                        fn clone(val: i32) -> i32 {{
+                            #[link(wasm_import_module = \"canonical_abi\")]
+                            extern \"C\" {{
+                                #[link_name = \"resource_clone_{name}\"]
+                                fn clone(val: i32) -> i32;
+                            }}
+                            unsafe {{ clone(val) }}
+                        }}
+
+                        #[inline]
+                        fn drop(val: i32) {{
+                            #[link(wasm_import_module = \"canonical_abi\")]
+                            extern \"C\" {{
+                                #[link_name = \"resource_drop_{name}\"]
+                                fn drop(val: i32);
+                            }}
+                            unsafe {{ drop(val) }}
+                        }}
+                    }}
+
+                    unsafe impl witx_bindgen_rust::LocalHandle for super::{ty} {{
+                        #[inline]
+                        fn new(val: i32) -> i32 {{
+                            #[link(wasm_import_module = \"canonical_abi\")]
+                            extern \"C\" {{
+                                #[link_name = \"resource_new_{name}\"]
+                                fn new(val: i32) -> i32;
+                            }}
+                            unsafe {{ new(val) }}
+                        }}
+
+                        #[inline]
+                        fn get(val: i32) -> i32 {{
+                            #[link(wasm_import_module = \"canonical_abi\")]
+                            extern \"C\" {{
+                                #[link_name = \"resource_get_{name}\"]
+                                fn get(val: i32) -> i32;
+                            }}
+                            unsafe {{ get(val) }}
+                        }}
+                    }}
+
+                    const _: () = {{
+                        #[export_name = \"{ns}canonical_abi_drop_{name}\"]
+                        extern \"C\" fn drop(ty: Box<super::{ty}>) {{
+                            super::{iface}().drop_{name_snake}(*ty)
+                        }}
+                    }};
+                ",
+                ty = iface.resources[ty].name.to_camel_case(),
+                name = iface.resources[ty].name,
+                name_snake = iface.resources[ty].name.to_snake_case(),
+                iface = iface.name.to_snake_case(),
+                ns = self.opts.symbol_namespace,
+            ));
+            let trait_ = self
+                .traits
+                .entry(iface.name.to_camel_case())
+                .or_insert(Trait::default());
+            trait_.methods.push(format!(
+                "
+                    /// An optional callback invoked when a handle is finalized
+                    /// and destroyed.
+                    fn drop_{}(&self, val: super::{}) {{
+                        drop(val);
+                    }}
+                ",
+                iface.resources[ty].name.to_snake_case(),
+                iface.resources[ty].name.to_camel_case(),
+            ));
             return;
         }
+
         let resource = &iface.resources[ty];
         let name = &resource.name;
 
@@ -290,7 +363,7 @@ impl Generator for RustWasm {
                 pub fn as_raw(&self) -> i32 {
                     self.0
                 }
-            }",
+            }\n",
         );
 
         self.src.push_str("impl Drop for ");
@@ -303,7 +376,7 @@ impl Generator for RustWasm {
                             drop({}_close({}(self.0)));
                         }}
                     }}
-                }}",
+                }}\n",
                 name,
                 name.to_camel_case(),
             ));
@@ -320,7 +393,7 @@ impl Generator for RustWasm {
                             close(self.0);
                         }}
                     }}
-                }}",
+                }}\n",
                 name,
             ));
         }
@@ -423,10 +496,8 @@ impl Generator for RustWasm {
         let FunctionBindgen {
             needs_cleanup_list,
             src,
-            handles_for_func,
             ..
         } = f;
-        assert!(handles_for_func.is_empty());
 
         if needs_cleanup_list {
             self.src.push_str("let mut cleanup_list = Vec::new();\n");
@@ -445,7 +516,7 @@ impl Generator for RustWasm {
 
         self.src.push_str("#[export_name = \"");
         self.src.push_str(&self.opts.symbol_namespace);
-        self.src.push_str(&rust_name);
+        self.src.push_str(&func.name);
         self.src.push_str("\"]\n");
         self.src.push_str("unsafe extern \"C\" fn __witx_bindgen_");
         self.src.push_str(&rust_name);
@@ -482,7 +553,6 @@ impl Generator for RustWasm {
         let FunctionBindgen {
             needs_cleanup_list,
             src,
-            handles_for_func,
             ..
         } = f;
         assert!(!needs_cleanup_list);
@@ -498,12 +568,9 @@ impl Generator for RustWasm {
             Unsafe::No,
             Async::No,
             Some("&self"),
-            if is_dtor {
-                TypeMode::Owned
-            } else {
-                TypeMode::HandlesBorrowed("'_")
-            },
+            TypeMode::Owned,
         );
+        self.src.push_str(";");
         self.in_trait = false;
         let trait_ = self
             .traits
@@ -512,24 +579,24 @@ impl Generator for RustWasm {
         trait_
             .methods
             .push(mem::replace(&mut self.src, prev).into());
-        trait_.handles.extend(handles_for_func);
     }
 
     fn finish(&mut self, _iface: &Interface, files: &mut Files) {
         let mut src = mem::take(&mut self.src);
 
+        for handle in self.imported_handles.iter() {
+            src.push_str("use super::");
+            src.push_str(handle);
+            src.push_str(";\n");
+        }
+
         for (name, trait_) in self.traits.iter() {
             src.push_str("pub trait ");
             src.push_str(&name);
             src.push_str(": Sized {\n");
-            for h in trait_.handles.iter() {
-                src.push_str("type ");
-                src.push_str(&h.to_camel_case());
-                src.push_str(";\n");
-            }
             for f in trait_.methods.iter() {
                 src.push_str(&f);
-                src.push_str(";\n");
+                src.push_str("\n");
             }
             src.push_str("}\n");
         }
@@ -581,7 +648,6 @@ struct FunctionBindgen<'a> {
     needs_cleanup_list: bool,
     cleanup: Vec<(String, String)>,
     is_dtor: bool,
-    handles_for_func: BTreeSet<String>,
 }
 
 impl FunctionBindgen<'_> {
@@ -596,7 +662,6 @@ impl FunctionBindgen<'_> {
             tmp: 0,
             needs_cleanup_list: false,
             cleanup: Vec::new(),
-            handles_for_func: BTreeSet::new(),
         }
     }
 }
@@ -777,25 +842,33 @@ impl Bindgen for FunctionBindgen<'_> {
                 witx_bindgen_gen_rust::bitcast(casts, operands, results)
             }
 
+            // handles in exports
             Instruction::I32FromOwnedHandle { ty } => {
-                self.handles_for_func
-                    .insert(iface.resources[*ty].name.to_string());
-                results.push(format!("Box::into_raw(Box::new({})) as i32", operands[0]));
+                self.gen
+                    .imported_handles
+                    .insert(iface.resources[*ty].name.to_camel_case());
+                results.push(format!(
+                    "witx_bindgen_rust::Handle::into_raw({})",
+                    operands[0]
+                ));
             }
+            Instruction::HandleBorrowedFromI32 { ty } => {
+                assert!(!self.is_dtor);
+                self.gen
+                    .imported_handles
+                    .insert(iface.resources[*ty].name.to_camel_case());
+                results.push(format!(
+                    "witx_bindgen_rust::Handle::from_raw({})",
+                    operands[0],
+                ));
+            }
+
+            // handles in imports
             Instruction::I32FromBorrowedHandle { .. } => {
                 if self.is_dtor {
                     results.push(format!("{}.into_raw()", operands[0]));
                 } else {
                     results.push(format!("{}.0", operands[0]));
-                }
-            }
-            Instruction::HandleBorrowedFromI32 { ty } => {
-                self.handles_for_func
-                    .insert(iface.resources[*ty].name.to_string());
-                if self.is_dtor {
-                    results.push(format!("*Box::from_raw({} as *mut _)", operands[0],));
-                } else {
-                    results.push(format!("&*({} as *const _)", operands[0],));
                 }
             }
             Instruction::HandleOwnedFromI32 { ty } => {

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -25,7 +25,7 @@ pub struct RustWasm {
     imported_handles: BTreeSet<String>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
 pub struct Opts {
     /// Whether or not `rustfmt` is executed to format generated code.

--- a/crates/gen-rust-wasm/tests/run.rs
+++ b/crates/gen-rust-wasm/tests/run.rs
@@ -34,10 +34,5 @@ mod exports {
         //
         // TODO: should fix this
         "!wasi_next.witx"
-
-        // If you want to exclude other test you can include it here with
-        // gitignore glob syntax:
-        //
-        // "!wasm.witx"
     );
 }

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -52,6 +52,7 @@ pub trait RustGenerator {
     );
     fn default_param_mode(&self) -> TypeMode;
     fn handle_projection(&self) -> Option<(&'static str, String)>;
+    fn handle_wrapper(&self) -> Option<&'static str>;
 
     fn rustdoc(&mut self, docs: &Docs) {
         let docs = match &docs.contents {
@@ -203,11 +204,20 @@ pub trait RustGenerator {
                     self.push_str(" ");
                 }
 
+                let suffix = match self.handle_wrapper() {
+                    Some(wrapper) => {
+                        self.push_str(wrapper);
+                        self.push_str("<");
+                        ">"
+                    }
+                    None => "",
+                };
                 if let Some((proj, _)) = self.handle_projection() {
                     self.push_str(proj);
                     self.push_str("::");
                 }
                 self.push_str(&iface.resources[*r].name.to_camel_case());
+                self.push_str(suffix);
             }
 
             Type::U8 => self.push_str("u8"),

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -60,7 +60,7 @@ struct Exports {
     funcs: Vec<String>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
 pub struct Opts {
     /// Whether or not `rustfmt` is executed to format generated code.
@@ -85,7 +85,7 @@ pub struct Opts {
     pub custom_error: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Async {
     None,
     All,
@@ -927,7 +927,7 @@ impl Generator for Wasmtime {
                 self.src.push_str(&format!(
                     "fn drop_{}(&mut self, state: Self::{}) {{
                         drop(state);
-                    }}",
+                    }}\n",
                     handle,
                     handle.to_camel_case(),
                 ));

--- a/crates/gen-wasmtime/tests/run.rs
+++ b/crates/gen-wasmtime/tests/run.rs
@@ -30,15 +30,9 @@ mod exports {
         "!typenames.witx"
         "!wasi_snapshot_preview1.witx"
 
-        // This uses handles, which we don't support in exports just yet
+        // This uses buffers, which we don't support in exports just yet
         // TODO: should support this
-        "!wasi_types.witx"
         "!wasi_next.witx"
-
-        // If you want to exclude other test you can include it here with
-        // gitignore glob syntax:
-        //
-        // "!wasm.witx"
     );
 }
 

--- a/crates/rust-wasm/src/lib.rs
+++ b/crates/rust-wasm/src/lib.rs
@@ -1,7 +1,122 @@
+use std::fmt;
+use std::marker;
+use std::mem;
+use std::ops::Deref;
 pub use witx_bindgen_rust_impl::{export, import};
 
 pub mod exports;
 pub mod imports;
+
+/// A type for handles to resources that appear in exported functions.
+///
+/// This type is used as `Handle<T>` for argument types and return values of
+/// exported functions when exposing a Rust-defined resource. A `Handle<T>`
+/// represents an owned reference count on the interface-types-managed resource.
+/// It's similar to an `Rc<T>` in Rust. Internally a `Handle<T>` can provide
+/// access to `&T` when `T` is defined in the current module.
+pub struct Handle<T: HandleType> {
+    val: i32,
+    _marker: marker::PhantomData<T>,
+}
+
+impl<T: HandleType> Handle<T> {
+    /// Creates a new handle around the specified value.
+    ///
+    /// Note that the lifetime of `T` will afterwards be managed by the
+    /// interface types runtime. The host may hold references to `T` that wasm
+    /// isn't necessarily aware of, preventing its destruction. Nevertheless
+    /// though the `Drop for T` implementation will still be run when there are
+    /// no more references to `T`.
+    pub fn new(val: T) -> Handle<T>
+    where
+        T: LocalHandle,
+    {
+        unsafe { Handle::from_raw(T::new(Box::into_raw(Box::new(val)) as i32)) }
+    }
+
+    /// Consumes a handle and returns the underlying raw wasm i32 descriptor.
+    ///
+    /// Note that this, if used improperly, will leak the resource `T`. This
+    /// generally should be avoided unless you're calling raw ABI bindings and
+    /// managing the lifetime manually.
+    pub fn into_raw(handle: Handle<T>) -> i32 {
+        let ret = handle.val;
+        mem::forget(handle);
+        ret
+    }
+
+    /// Returns the raw underlying handle value for this handle.
+    ///
+    /// This typically isn't necessary to interact with, but can be useful when
+    /// interacting with raw ABI bindings.
+    pub fn as_raw(handle: &Handle<T>) -> i32 {
+        handle.val
+    }
+
+    /// Unsafely assumes that the given integer descriptor is a handle for `T`.
+    ///
+    /// This is unsafe because no validation is performed to ensure that `val`
+    /// is actually a valid descriptor for `T`.
+    pub unsafe fn from_raw(val: i32) -> Handle<T> {
+        Handle {
+            val,
+            _marker: marker::PhantomData,
+        }
+    }
+}
+
+impl<T: LocalHandle> Deref for Handle<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*(T::get(self.val) as *const T) }
+    }
+}
+
+impl<T: LocalHandle> From<T> for Handle<T> {
+    fn from(val: T) -> Handle<T> {
+        Handle::new(val)
+    }
+}
+
+impl<T: HandleType> Clone for Handle<T> {
+    fn clone(&self) -> Self {
+        unsafe { Handle::from_raw(T::clone(self.val)) }
+    }
+}
+
+impl<T: HandleType> fmt::Debug for Handle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Handle").field("val", &self.val).finish()
+    }
+}
+
+impl<T: HandleType> Drop for Handle<T> {
+    fn drop(&mut self) {
+        T::drop(self.val);
+    }
+}
+
+/// A trait for types that can show up as the `T` in `Handle<T>`.
+///
+/// This trait is automatically synthesized for exported handles and typically
+/// shouldn't be implemented manually.
+pub unsafe trait HandleType {
+    #[doc(hidden)]
+    fn clone(val: i32) -> i32;
+    #[doc(hidden)]
+    fn drop(val: i32);
+}
+
+/// An extension of the [`HandleType`] trait for locally-defined types.
+///
+/// This trait may not stick around forever...
+pub unsafe trait LocalHandle: HandleType {
+    #[doc(hidden)]
+    fn new(val: i32) -> i32;
+    #[doc(hidden)]
+    fn get(val: i32) -> i32;
+}
 
 #[doc(hidden)]
 pub mod rt {

--- a/crates/test-rust-wasm/src/exports.rs
+++ b/crates/test-rust-wasm/src/exports.rs
@@ -5,6 +5,7 @@ witx_bindgen_rust::export!("tests/wasm.witx");
 witx_bindgen_rust::export!({ paths: ["tests/wasm.witx"], unchecked });
 
 use wasm::*;
+use witx_bindgen_rust::Handle;
 
 use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
 // use witx_bindgen_rust::exports::{InBuffer, InBufferRaw, OutBuffer, OutBufferRaw};
@@ -22,14 +23,11 @@ fn wasm() -> &'static impl Wasm {
     &ME
 }
 
-struct MyType(u32);
+pub struct WasmState(u32);
 
-struct MyType2(u32);
+pub struct WasmState2(u32);
 
 impl Wasm for MyWasm {
-    // type WasmState = MyType;
-    // type WasmState2 = MyType2;
-
     fn allocated_bytes(&self) -> u32 {
         crate::allocator::get() as u32
     }
@@ -245,55 +243,61 @@ impl Wasm for MyWasm {
         (b"typedef3".to_vec(), vec!["typedef4".to_string()])
     }
 
-    // fn wasm_state_create(&self) -> MyType {
-    //     MyType(100)
-    // }
+    fn wasm_state_create(&self) -> Handle<WasmState> {
+        WasmState(100).into()
+    }
 
-    // fn wasm_state_get(&self, state: &MyType) -> u32 {
-    //     state.0
-    // }
+    fn wasm_state_get(&self, state: Handle<WasmState>) -> u32 {
+        state.0
+    }
 
-    // fn wasm_state2_create(&self) -> MyType2 {
-    //     MyType2(33)
-    // }
+    fn wasm_state2_create(&self) -> Handle<WasmState2> {
+        WasmState2(33).into()
+    }
 
-    // fn wasm_state2_saw_close(&self) -> bool {
-    //     self.wasm_state2_closed.load(SeqCst) != 0
-    // }
+    fn wasm_state2_saw_close(&self) -> bool {
+        self.wasm_state2_closed.load(SeqCst) != 0
+    }
 
-    // fn wasm_state2_close(&self, _state: MyType2) {
-    //     self.wasm_state2_closed.store(1, SeqCst);
-    // }
+    fn drop_wasm_state2(&self, _state: WasmState2) {
+        self.wasm_state2_closed.store(1, SeqCst);
+    }
 
-    // fn two_wasm_states(&self, _a: &MyType, _b: &MyType2) -> (MyType, MyType2) {
-    //     (MyType(101), MyType2(102))
-    // }
+    fn two_wasm_states(
+        &self,
+        _a: Handle<WasmState>,
+        _b: Handle<WasmState2>,
+    ) -> (Handle<WasmState>, Handle<WasmState2>) {
+        (WasmState(101).into(), WasmState2(102).into())
+    }
 
-    // fn wasm_state2_param_record(&self, _a: WasmStateParamRecord<'_, Self>) {}
-    // fn wasm_state2_param_tuple(&self, _a: (&'_ MyType2,)) {}
-    // fn wasm_state2_param_option(&self, _a: Option<&'_ MyType2>) {}
-    // fn wasm_state2_param_result(&self, _a: Result<&'_ MyType2, u32>) {}
-    // fn wasm_state2_param_variant(&self, _a: WasmStateParamVariant<'_, Self>) {}
-    // fn wasm_state2_param_list(&self, _a: Vec<&MyType2>) {}
+    fn wasm_state2_param_record(&self, _a: WasmStateParamRecord) {}
+    fn wasm_state2_param_tuple(&self, _a: (Handle<WasmState2>,)) {}
+    fn wasm_state2_param_option(&self, _a: Option<Handle<WasmState2>>) {}
+    fn wasm_state2_param_result(&self, _a: Result<Handle<WasmState2>, u32>) {}
+    fn wasm_state2_param_variant(&self, _a: WasmStateParamVariant) {}
+    fn wasm_state2_param_list(&self, _a: Vec<Handle<WasmState2>>) {}
 
-    // fn wasm_state2_result_record(&self) -> WasmStateResultRecord<Self> {
-    //     WasmStateResultRecord { a: MyType2(222) }
-    // }
-    // fn wasm_state2_result_tuple(&self) -> (MyType2,) {
-    //     (MyType2(333),)
-    // }
-    // fn wasm_state2_result_option(&self) -> Option<MyType2> {
-    //     Some(MyType2(444))
-    // }
-    // fn wasm_state2_result_result(&self) -> Result<MyType2, u32> {
-    //     Ok(MyType2(555))
-    // }
-    // fn wasm_state2_result_variant(&self) -> WasmStateResultVariant<Self> {
-    //     WasmStateResultVariant::V0(MyType2(666))
-    // }
-    // fn wasm_state2_result_list(&self) -> Vec<MyType2> {
-    //     vec![MyType2(777), MyType2(888)]
-    // }
+    fn wasm_state2_result_record(&self) -> WasmStateResultRecord {
+        WasmStateResultRecord {
+            a: WasmState2(222).into(),
+        }
+    }
+    fn wasm_state2_result_tuple(&self) -> (Handle<WasmState2>,) {
+        (WasmState2(333).into(),)
+    }
+    fn wasm_state2_result_option(&self) -> Option<Handle<WasmState2>> {
+        Some(WasmState2(444).into())
+    }
+    fn wasm_state2_result_result(&self) -> Result<Handle<WasmState2>, u32> {
+        Ok(WasmState2(555).into())
+    }
+    fn wasm_state2_result_variant(&self) -> WasmStateResultVariant {
+        WasmStateResultVariant::V0(Handle::new(WasmState2(666)))
+    }
+    fn wasm_state2_result_list(&self) -> Vec<Handle<WasmState2>> {
+        vec![WasmState2(777).into(), WasmState2(888).into()]
+    }
 
     // fn buffer_u8(&self, in_: InBufferRaw<'_, u8>, out: OutBufferRaw<'_, u8>) -> u32 {
     //     assert_eq!(in_.len(), 1);

--- a/crates/wasmtime/src/exports.rs
+++ b/crates/wasmtime/src/exports.rs
@@ -1,3 +1,4 @@
+use crate::slab::Slab;
 use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::mem;
@@ -296,54 +297,6 @@ impl Drop for BufferTransaction<'_> {
             } else {
                 inner.in_buffers.remove(*handle);
             }
-        }
-    }
-}
-
-struct Slab<T> {
-    storage: Vec<Entry<T>>,
-    next: usize,
-}
-
-enum Entry<T> {
-    Full(T),
-    Empty { next: usize },
-}
-
-impl<T> Slab<T> {
-    fn insert(&mut self, item: T) -> u32 {
-        if self.next == self.storage.len() {
-            self.storage.push(Entry::Empty {
-                next: self.next + 1,
-            });
-        }
-        let ret = self.next as u32;
-        let entry = Entry::Full(item);
-        self.next = match mem::replace(&mut self.storage[self.next], entry) {
-            Entry::Empty { next } => next,
-            _ => unreachable!(),
-        };
-        return ret;
-    }
-
-    fn get_mut(&mut self, idx: u32) -> Option<&mut T> {
-        match self.storage.get_mut(idx as usize)? {
-            Entry::Full(b) => Some(b),
-            Entry::Empty { .. } => None,
-        }
-    }
-
-    fn remove(&mut self, idx: u32) {
-        self.storage[idx as usize] = Entry::Empty { next: self.next };
-        self.next = idx as usize;
-    }
-}
-
-impl<T> Default for Slab<T> {
-    fn default() -> Slab<T> {
-        Slab {
-            storage: Vec::new(),
-            next: 0,
         }
     }
 }

--- a/crates/wasmtime/src/slab.rs
+++ b/crates/wasmtime/src/slab.rs
@@ -1,0 +1,72 @@
+use std::fmt;
+use std::mem;
+
+pub struct Slab<T> {
+    storage: Vec<Entry<T>>,
+    next: usize,
+}
+
+enum Entry<T> {
+    Full(T),
+    Empty { next: usize },
+}
+
+impl<T> Slab<T> {
+    pub fn insert(&mut self, item: T) -> u32 {
+        if self.next == self.storage.len() {
+            self.storage.push(Entry::Empty {
+                next: self.next + 1,
+            });
+        }
+        let ret = self.next as u32;
+        let entry = Entry::Full(item);
+        self.next = match mem::replace(&mut self.storage[self.next], entry) {
+            Entry::Empty { next } => next,
+            _ => unreachable!(),
+        };
+        return ret;
+    }
+
+    pub fn get(&self, idx: u32) -> Option<&T> {
+        match self.storage.get(idx as usize)? {
+            Entry::Full(b) => Some(b),
+            Entry::Empty { .. } => None,
+        }
+    }
+
+    pub fn get_mut(&mut self, idx: u32) -> Option<&mut T> {
+        match self.storage.get_mut(idx as usize)? {
+            Entry::Full(b) => Some(b),
+            Entry::Empty { .. } => None,
+        }
+    }
+
+    pub fn remove(&mut self, idx: u32) -> Option<T> {
+        let slot = self.storage.get_mut(idx as usize)?;
+        match mem::replace(slot, Entry::Empty { next: self.next }) {
+            Entry::Full(b) => {
+                self.next = idx as usize;
+                Some(b)
+            }
+            Entry::Empty { next } => {
+                *slot = Entry::Empty { next };
+                None
+            }
+        }
+    }
+}
+
+impl<T> Default for Slab<T> {
+    fn default() -> Slab<T> {
+        Slab {
+            storage: Vec::new(),
+            next: 0,
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Slab<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Slab").finish()
+    }
+}

--- a/crates/wasmtime/tests/run/main.rs
+++ b/crates/wasmtime/tests/run/main.rs
@@ -25,6 +25,7 @@ pub struct Context {
     wasi: wasmtime_wasi::WasiCtx,
     imports: imports::MyHost,
     tables: imports::HostTables<imports::MyHost>,
+    export_data: exports::WasmData,
 }
 
 fn run_test(engine: &Engine, wasm: &str) -> Result<()> {
@@ -45,11 +46,14 @@ fn run_test(engine: &Engine, wasm: &str) -> Result<()> {
                 .build(),
             imports: Default::default(),
             tables: Default::default(),
+            export_data: Default::default(),
         },
     );
-    // let instance = linker.instantiate(&mut store, &module)?;
 
-    let exports = exports::Wasm::new(&mut store, &module, &mut linker)?;
-    exports::test(&exports, &mut store)?;
+    let (exports, instance) =
+        exports::Wasm::instantiate(&mut store, &module, &mut linker, |state| {
+            &mut state.export_data
+        })?;
+    exports::test(&exports, instance, &mut store)?;
     Ok(())
 }

--- a/crates/witx2/src/abi.rs
+++ b/crates/witx2/src/abi.rs
@@ -281,6 +281,10 @@ def_instruction! {
 
         /// Converts a "borrowed" handle into a wasm `i32` value.
         ///
+        /// > **Note**: this documentation is outdated and does not reflect the
+        /// > current implementation of the canonical ABI. This needs to be
+        /// > updated.
+        ///
         /// A "borrowed" handle in this case means one where ownership is not
         /// being relinquished. This is only used for lowering interface types
         /// parameters.
@@ -304,6 +308,10 @@ def_instruction! {
         I32FromBorrowedHandle { ty: ResourceId } : [1] => [1],
 
         /// Converts an "owned" handle into a wasm `i32` value.
+        ///
+        /// > **Note**: this documentation is outdated and does not reflect the
+        /// > current implementation of the canonical ABI. This needs to be
+        /// > updated.
         ///
         /// This conversion is used for handle values which are crossing a
         /// module boundary for perhaps the first time. Some example cases of
@@ -340,6 +348,10 @@ def_instruction! {
 
         /// Converts a native wasm `i32` into an owned handle value.
         ///
+        /// > **Note**: this documentation is outdated and does not reflect the
+        /// > current implementation of the canonical ABI. This needs to be
+        /// > updated.
+        ///
         /// This is the converse of `I32FromOwnedHandle` and is used in similar
         /// situations:
         ///
@@ -358,6 +370,10 @@ def_instruction! {
         HandleOwnedFromI32 { ty: ResourceId } : [1] => [1],
 
         /// Converts a native wasm `i32` into a borrowedhandle value.
+        ///
+        /// > **Note**: this documentation is outdated and does not reflect the
+        /// > current implementation of the canonical ABI. This needs to be
+        /// > updated.
         ///
         /// This is the converse of `I32FromBorrowedHandle` and is used in similar
         /// situations:

--- a/tests/resource.witx
+++ b/tests/resource.witx
@@ -1,0 +1,4 @@
+resource x
+
+acquire_an_x: function() -> x
+receive_an_x: function(val: x)

--- a/tests/wasm.witx
+++ b/tests/wasm.witx
@@ -64,11 +64,8 @@
   (typename $list_typedef2 (list u8))
   (typename $list_typedef3 (list string))
 
-(;
   (resource $wasm_state)
-  (typename $wasm_state (handle $wasm_state))
   (resource $wasm_state2)
-  (typename $wasm_state2 (handle $wasm_state2))
 
   (typename $wasm_state_param_record (record (field $a $wasm_state2)))
   (typename $wasm_state_param_tuple (tuple $wasm_state2))
@@ -81,7 +78,6 @@
   (typename $wasm_state_result_option (option $wasm_state2))
   (typename $wasm_state_result_result (expected $wasm_state2 (error u32)))
   (typename $wasm_state_result_variant (union $wasm_state2 u32))
-;)
 
   (typename $buffer_in_variant (variant
     (case $a (in-buffer u8))
@@ -177,15 +173,12 @@
   (export "list_result3" (func (result $a (list string))))
   (export "string_roundtrip" (func (param $a string) (result $b string)))
 
-  (;
   ;; ===========================================
   ;; handles
   ;; ===========================================
-  (;
   (export "wasm_state_create" (func (result $a $wasm_state)))
   (export "wasm_state_get" (func (param $a $wasm_state) (result $b u32)))
   (export "wasm_state2_create" (func (result $b $wasm_state2)))
-  (export "wasm_state2_close" (func (param $a $wasm_state2)))
   (export "wasm_state2_saw_close" (func (result $a bool)))
 
   (export "two_wasm_states" (func
@@ -208,8 +201,8 @@
   (export "wasm_state2_result_result" (func (result $a $wasm_state_result_result)))
   (export "wasm_state2_result_variant" (func (result $a $wasm_state_result_variant)))
   (export "wasm_state2_result_list" (func (result $a (list $wasm_state2))))
-  ;)
 
+  (;
   ;; ===========================================
   ;; buffers
   ;; ===========================================


### PR DESCRIPTION
This commit goes over the implemented generators and reimplements
exported resource types. This was implemented historically but in the
most recent revision of the canonical ABI various bits and pieces had
changed and this project hadn't been updated yet. This updates all the
various generators to the most recent version of the canonical ABI and
adds tests/etc. Mostly this just uncomments the existing tests and gets
them working.

The main change from before is that handles crossing the abi boundary
are always table indices rather than sometimes indices and sometimes
pointers. The boxing happens internally within the wasm module and the
host is responsible for managing tables. Additionally all host resources
are implicitly reference counted, although hosts don't necessarily have
to expose that to their runtimes. For example the reference counting is
optional in JS with a `FinalizationRegistry` used for cleanup.