### PR TITLE
Disable fail fast for CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         mode: [debug, release]


### PR DESCRIPTION
This will allow the Windows CI to fail while the rest of the CI jobs run in the
matrix.