### PR TITLE
Fix issues with generators and conventions

### DIFF
--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -683,11 +683,10 @@ impl Generator for Js {
                 .ts(&format!("export interface {} {{\n", module.to_camel_case()));
 
             for f in funcs {
-                let func = f.name.to_snake_case();
                 self.src.js(&format!(
                     "imports[\"{}\"][\"{}\"] = {};\n",
                     module,
-                    func,
+                    f.name,
                     f.src.js.trim(),
                 ));
                 self.src.ts(&f.src.ts);

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -1258,7 +1258,7 @@ impl Bindgen for FunctionBindgen<'_> {
                 self.push_str("<_ as ");
                 self.push_str(&module.to_camel_case());
                 self.push_str(">::");
-                self.push_str(&func.name);
+                self.push_str(&func.name.to_snake_case());
                 self.push_str("(super::");
                 self.push_str(module);
                 self.push_str("(),");

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -149,7 +149,7 @@ pub trait RustGenerator {
             self.push_str("async ");
         }
         self.push_str("fn ");
-        self.push_str(to_rust_ident(&rust_name));
+        self.push_str(&to_rust_ident(&rust_name));
         if let Some(generics) = generics {
             self.push_str(generics);
         }
@@ -160,8 +160,9 @@ pub trait RustGenerator {
         }
         let mut params = Vec::new();
         for (name, param) in func.params.iter() {
-            self.push_str(to_rust_ident(name.as_str()));
-            params.push(to_rust_ident(name.as_str()).to_string());
+            let name = to_rust_ident(name);
+            self.push_str(&name);
+            params.push(name);
             self.push_str(": ");
             self.print_ty(iface, param, param_mode);
             self.push_str(",");
@@ -471,7 +472,7 @@ pub trait RustGenerator {
                 for field in record.fields.iter() {
                     self.rustdoc(&field.docs);
                     self.push_str("pub ");
-                    self.push_str(to_rust_ident(&field.name));
+                    self.push_str(&to_rust_ident(&field.name));
                     self.push_str(": ");
                     self.print_ty(iface, &field.ty, mode);
                     self.push_str(",\n");
@@ -858,8 +859,9 @@ pub trait RustFunctionGenerator {
             self.push_str(&name);
             self.push_str("{ ");
             for field in record.fields.iter() {
-                let arg = format!("{}{}", field.name.as_str(), tmp);
-                self.push_str(to_rust_ident(field.name.as_str()));
+                let name = to_rust_ident(&field.name);
+                let arg = format!("{}{}", name, tmp);
+                self.push_str(&name);
                 self.push_str(":");
                 self.push_str(&arg);
                 self.push_str(", ");
@@ -889,7 +891,7 @@ pub trait RustFunctionGenerator {
             let mut result = self.typename_lift(iface, id);
             result.push_str("{");
             for (field, val) in ty.fields.iter().zip(operands) {
-                result.push_str(to_rust_ident(&field.name));
+                result.push_str(&to_rust_ident(&field.name));
                 result.push_str(":");
                 result.push_str(&val);
                 result.push_str(", ");
@@ -1008,14 +1010,14 @@ pub trait RustFunctionGenerator {
     }
 }
 
-pub fn to_rust_ident(name: &str) -> &str {
+pub fn to_rust_ident(name: &str) -> String {
     match name {
-        "in" => "in_",
-        "type" => "type_",
-        "where" => "where_",
-        "yield" => "yield_",
-        "async" => "async_",
-        s => s,
+        "in" => "in_".into(),
+        "type" => "type_".into(),
+        "where" => "where_".into(),
+        "yield" => "yield_".into(),
+        "async" => "async_".into(),
+        s => s.to_snake_case(),
     }
 }
 

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -868,7 +868,7 @@ impl Generator for Wasmtime {
         }
         cvt.push_str(")");
         exports.fields.insert(
-            func.name.to_string(),
+            to_rust_ident(&func.name),
             (
                 format!("wasmtime::TypedFunc<{}>", cvt),
                 format!(
@@ -928,7 +928,7 @@ impl Generator for Wasmtime {
                     "fn drop_{}(&mut self, state: Self::{}) {{
                         drop(state);
                     }}\n",
-                    handle,
+                    handle.to_snake_case(),
                     handle.to_camel_case(),
                 ));
             }
@@ -1016,7 +1016,7 @@ impl Generator for Wasmtime {
                                 Ok(())
                             }}
                         )?;\n",
-                        handle
+                        handle.to_snake_case(),
                     ));
                 }
             }
@@ -2087,7 +2087,7 @@ impl Bindgen for FunctionBindgen<'_> {
                     self.push_str(") = ");
                 }
                 self.push_str("self.");
-                self.push_str(name);
+                self.push_str(&to_rust_ident(name));
                 if self.gen.opts.async_.includes(name) {
                     self.push_str(".call_async(");
                 } else {
@@ -2131,7 +2131,7 @@ impl Bindgen for FunctionBindgen<'_> {
                     self.push_str(".raw() };\n");
                 }
 
-                let mut call = format!("host.{}(", func.name);
+                let mut call = format!("host.{}(", func.name.to_snake_case());
                 if self.func_takes_all_memory {
                     call.push_str("raw_memory, ");
                 }

--- a/tests/conventions.witx
+++ b/tests/conventions.witx
@@ -1,0 +1,32 @@
+camelCase: function()
+snake_case: function()
+SHOUTY_SNAKE_CASE: function()
+
+record LUDICROUS_speed {
+  howFastAreYouGoing: u32,
+  "I am going extremely slow": u64,
+}
+
+foo: function(x: LUDICROUS_speed)
+"function with space": function()
+"function~with$weird&characters": function()
+
+type "type with space" = u64
+
+record "record with space" {
+  "field with space": "type with space",
+}
+
+variant "variant with space" {
+  "case with space",
+  "case2 with space"("record with space"),
+  "case3 with space"("type with space"),
+}
+
+resource "resource with space"
+
+"function again with space": function(
+  "a 1": "record with space",
+  "a 2": "variant with space",
+  "a 3": "resource with space",
+)


### PR DESCRIPTION
Mostly fix issues in Rust where there were mismatches in `to_snake_case`
vs not, and not all locations were calling `to_snake_case`. Lots of
compile failures for the included witx file here, and no compile
failures afterwards!