### PR TITLE
Flag `self` as a reserved word for Rust

### DIFF
--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -1017,6 +1017,7 @@ pub fn to_rust_ident(name: &str) -> String {
         "where" => "where_".into(),
         "yield" => "yield_".into(),
         "async" => "async_".into(),
+        "self" => "self_".into(),
         s => s.to_snake_case(),
     }
 }

--- a/tests/resource.witx
+++ b/tests/resource.witx
@@ -2,3 +2,9 @@ resource x
 
 acquire_an_x: function() -> x
 receive_an_x: function(val: x)
+
+resource y {
+  method_on_y: function()
+  method_with_param: function(x: u32)
+  method_with_result: function() -> string
+}


### PR DESCRIPTION
This also fixes resources-with-methods at least syntactically. I suspect
though we'll want to make the generated code more ergonomic to use in
the future.

Closes #33