### PR TITLE
Make fields of the `Tables` structure `pub(crate)`.

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -941,6 +941,7 @@ impl Generator for Wasmtime {
                 self.src.push_str(&module_camel);
                 self.src.push_str("> {\n");
                 for handle in self.all_needed_handles.iter() {
+                    self.src.push_str("pub(crate) ");
                     self.src.push_str(&handle.to_snake_case());
                     self.src
                         .push_str("_table: witx_bindgen_wasmtime::Table<T::");


### PR DESCRIPTION
This PR makes the fields of the Wasmtime `Tables` structure `pub(crate)`.

Without this, the underlying tables cannot be manipulated outside of the
generated code; for example, it might be useful to prepopulate some resources
in the tables prior to invoking any wasm code.