### PR TITLE
Fix send/sync bounds in imports

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -882,7 +882,7 @@ impl Generator for Wasmtime {
     fn finish(&mut self, iface: &Interface, files: &mut Files) {
         for (module, funcs) in sorted_iter(&self.imports) {
             let module_camel = module.to_camel_case();
-            let is_async = funcs.iter().any(|f| self.opts.async_.includes(&f.name));
+            let is_async = !self.opts.async_.is_none();
             if is_async {
                 self.src.push_str("#[witx_bindgen_wasmtime::async_trait]\n");
             }
@@ -965,7 +965,7 @@ impl Generator for Wasmtime {
 
         for (module, funcs) in mem::take(&mut self.imports) {
             let module_camel = module.to_camel_case();
-            let is_async = funcs.iter().any(|f| self.opts.async_.includes(&f.name));
+            let is_async = !self.opts.async_.is_none();
             self.push_str("\npub fn add_");
             self.push_str(&module);
             self.push_str("_to_linker<T, U>(linker: &mut wasmtime::Linker<T>");

--- a/crates/gen-wasmtime/tests/run.rs
+++ b/crates/gen-wasmtime/tests/run.rs
@@ -78,6 +78,16 @@ mod async_tests {
             async: ["bar"],
         });
     }
+    mod resource_with_none_async {
+        witx_bindgen_wasmtime::import!({
+            src["x"]: "
+                resource y {
+                    z: function() -> string
+                }
+            ",
+            async: [],
+        });
+    }
 }
 
 mod custom_errors {


### PR DESCRIPTION
Some locations in the code used a different condition for determining
whether async should be used from other locations, and this mismatch
caused issues in the generated code. Instead use `None` as the only
indicator of "no async anywhere" and otherwise assume that everything
needs to be async unless explicitly mentioned otherwise.

Closes #41