### PR TITLE
Add a markdown code generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "witx-bindgen-gen-c",
  "witx-bindgen-gen-core",
  "witx-bindgen-gen-js",
+ "witx-bindgen-gen-markdown",
  "witx-bindgen-gen-rust-wasm",
  "witx-bindgen-gen-wasmtime",
  "witx-bindgen-rust",
@@ -944,6 +945,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1453,15 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1960,6 +1981,7 @@ dependencies = [
  "witx-bindgen-gen-c",
  "witx-bindgen-gen-core",
  "witx-bindgen-gen-js",
+ "witx-bindgen-gen-markdown",
  "witx-bindgen-gen-rust-wasm",
  "witx-bindgen-gen-wasmtime",
 ]
@@ -1991,6 +2013,16 @@ dependencies = [
  "heck",
  "structopt",
  "test-codegen",
+ "witx-bindgen-gen-core",
+]
+
+[[package]]
+name = "witx-bindgen-gen-markdown"
+version = "0.1.0"
+dependencies = [
+ "heck",
+ "pulldown-cmark",
+ "structopt",
  "witx-bindgen-gen-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ witx-bindgen-gen-rust-wasm = { path = 'crates/gen-rust-wasm', features = ['struc
 witx-bindgen-gen-wasmtime = { path = 'crates/gen-wasmtime', features = ['structopt'] }
 witx-bindgen-gen-js = { path = 'crates/gen-js', features = ['structopt'] }
 witx-bindgen-gen-c = { path = 'crates/gen-c', features = ['structopt'] }
+witx-bindgen-gen-markdown = { path = 'crates/gen-markdown', features = ['structopt'] }

--- a/crates/demo/Cargo.toml
+++ b/crates/demo/Cargo.toml
@@ -16,4 +16,5 @@ witx-bindgen-gen-rust-wasm = { path = '../gen-rust-wasm' }
 witx-bindgen-gen-wasmtime = { path = '../gen-wasmtime' }
 witx-bindgen-gen-js = { path = '../gen-js' }
 witx-bindgen-gen-c = { path = '../gen-c' }
+witx-bindgen-gen-markdown = { path = '../gen-markdown' }
 witx-bindgen-rust = { path = '../rust-wasm' }

--- a/crates/demo/demo.witx
+++ b/crates/demo/demo.witx
@@ -11,6 +11,7 @@ enum lang {
   rust,
   wasmtime,
   c,
+  markdown,
 }
 
 

--- a/crates/demo/index.html
+++ b/crates/demo/index.html
@@ -53,6 +53,7 @@ hello: function(who: person) -&gt; string
             <option value="rust">Rust</option>
             <option value="wasmtime">Wasmtime</option>
             <option value="c">C</option>
+            <option value="markdown">Markdown</option>
           </select>
 
           &middot;
@@ -73,6 +74,8 @@ hello: function(who: person) -&gt; string
           <div id='configure-js' class='lang-configure'>
           </div>
           <div id='configure-c' class='lang-configure'>
+          </div>
+          <div id='configure-markdown' class='lang-configure'>
           </div>
           <div id='configure-rust' class='lang-configure'>
             &middot;
@@ -99,6 +102,7 @@ hello: function(who: person) -&gt; string
         </div>
 
         <div class='editor' id='output'></div>
+        <div id='html-output'></div>
       </div>
   </body>
   <script src="ace/ace.js"></script>

--- a/crates/demo/main.ts
+++ b/crates/demo/main.ts
@@ -16,6 +16,7 @@ class Editor {
   rerender: number | null;
   inputEditor: AceAjax.Editor;
   outputEditor: AceAjax.Editor;
+  outputHtml: HTMLDivElement;
 
   constructor() {
     this.input = document.getElementById('input-raw') as HTMLTextAreaElement;
@@ -26,6 +27,7 @@ class Editor {
     this.wasmtimeTracing = document.getElementById('wasmtime-tracing') as HTMLInputElement;
     this.wasmtimeAsync = document.getElementById('wasmtime-async') as HTMLInputElement;
     this.wasmtimeCustomError = document.getElementById('wasmtime-custom-error') as HTMLInputElement;
+    this.outputHtml = document.getElementById('html-output') as HTMLDivElement;
 
     this.inputEditor = ace.edit("input");
     this.outputEditor = ace.edit("output");
@@ -107,12 +109,14 @@ class Editor {
       case "rust": lang = Lang.Rust; break;
       case "wasmtime": lang = Lang.Wasmtime; break;
       case "c": lang = Lang.C; break;
+      case "markdown": lang = Lang.Markdown; break;
       default: return;
     }
     const result = this.demo.render(this.config, lang, witx, is_import);
     if (result.tag === 'err') {
       this.outputEditor.setValue(result.val);
       this.outputEditor.clearSelection();
+      this.showOutputEditor();
       return;
     }
     this.generatedFiles = {};
@@ -130,7 +134,25 @@ class Editor {
     this.updateSelectedFile();
   }
 
+  showOutputEditor() {
+    this.outputHtml.style.display = 'none';
+    document.getElementById('output').style.display = 'block';
+  }
+
+  showOutputHtml() {
+    this.outputHtml.style.display = 'block';
+    document.getElementById('output').style.display = 'none';
+  }
+
   updateSelectedFile() {
+    if (this.files.value.endsWith('.html')) {
+      const html = this.generatedFiles[this.files.value];
+      this.outputHtml.innerHTML = html;
+      this.showOutputHtml();
+      return;
+    }
+
+    this.showOutputEditor();
     this.outputEditor.setValue(this.generatedFiles[this.files.value]);
     this.outputEditor.clearSelection();
     if (this.files.value.endsWith('.d.ts'))
@@ -143,6 +165,8 @@ class Editor {
       this.outputEditor.session.setMode("ace/mode/c_cpp");
     else if (this.files.value.endsWith('.h'))
       this.outputEditor.session.setMode("ace/mode/c_cpp");
+    else if (this.files.value.endsWith('.md'))
+      this.outputEditor.session.setMode("ace/mode/markdown");
     else
       this.outputEditor.session.setMode(null);
   }

--- a/crates/demo/src/lib.rs
+++ b/crates/demo/src/lib.rs
@@ -28,6 +28,7 @@ pub struct Config {
     c: RefCell<witx_bindgen_gen_c::Opts>,
     rust: RefCell<witx_bindgen_gen_rust_wasm::Opts>,
     wasmtime: RefCell<witx_bindgen_gen_wasmtime::Opts>,
+    markdown: RefCell<witx_bindgen_gen_markdown::Opts>,
 }
 
 impl demo::Demo for Demo {
@@ -47,6 +48,7 @@ impl demo::Demo for Demo {
             demo::Lang::Wasmtime => Box::new(config.wasmtime.borrow().clone().build()),
             demo::Lang::Js => Box::new(config.js.borrow().clone().build()),
             demo::Lang::C => Box::new(config.c.borrow().clone().build()),
+            demo::Lang::Markdown => Box::new(config.markdown.borrow().clone().build()),
         };
         let iface = witx2::Interface::parse("input", &witx).map_err(|e| format!("{:?}", e))?;
         let mut files = Default::default();

--- a/crates/gen-core/src/lib.rs
+++ b/crates/gen-core/src/lib.rs
@@ -366,6 +366,14 @@ impl Source {
         }
     }
 
+    pub fn indent(&mut self, amt: usize) {
+        self.indent += amt;
+    }
+
+    pub fn deindent(&mut self, amt: usize) {
+        self.indent -= amt;
+    }
+
     fn newline(&mut self) {
         self.s.push_str("\n");
         for _ in 0..self.indent {

--- a/crates/gen-markdown/Cargo.toml
+++ b/crates/gen-markdown/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "witx-bindgen-gen-markdown"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+heck = "0.3"
+pulldown-cmark = { version = "0.8", default-features = false }
+structopt = { version = "0.3", default-features = false, optional = true }
+witx-bindgen-gen-core = { path = '../gen-core', version = '0.1.0' }

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -1,0 +1,373 @@
+use heck::*;
+use pulldown_cmark::{html, Event, LinkType, Parser, Tag};
+use std::collections::HashMap;
+use witx2::abi::Direction;
+use witx2::*;
+use witx_bindgen_gen_core::{witx2, Files, Generator, Source};
+
+#[derive(Default)]
+pub struct Markdown {
+    src: Source,
+    opts: Opts,
+    sizes: SizeAlign,
+    hrefs: HashMap<String, String>,
+    funcs: usize,
+    types: usize,
+}
+
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+pub struct Opts {
+    // ...
+}
+
+impl Opts {
+    pub fn build(&self) -> Markdown {
+        let mut r = Markdown::new();
+        r.opts = self.clone();
+        r
+    }
+}
+
+impl Markdown {
+    pub fn new() -> Markdown {
+        Markdown::default()
+    }
+
+    fn print_ty(&mut self, iface: &Interface, ty: &Type, skip_name: bool) {
+        match ty {
+            Type::U8 => self.src.push_str("`u8`"),
+            Type::S8 => self.src.push_str("`s8`"),
+            Type::U16 => self.src.push_str("`u16`"),
+            Type::S16 => self.src.push_str("`s16`"),
+            Type::U32 => self.src.push_str("`u32`"),
+            Type::S32 => self.src.push_str("`s32`"),
+            Type::U64 => self.src.push_str("`u64`"),
+            Type::S64 => self.src.push_str("`s64`"),
+            Type::F32 => self.src.push_str("`f32`"),
+            Type::F64 => self.src.push_str("`f64`"),
+            Type::Char => self.src.push_str("`char`"),
+            Type::CChar => self.src.push_str("`c_char`"),
+            Type::Usize => self.src.push_str("`usize`"),
+            Type::Handle(id) => {
+                self.src.push_str("handle<");
+                self.src.push_str(&iface.resources[*id].name);
+                self.src.push_str(">");
+            }
+            Type::Id(id) => {
+                let ty = &iface.types[*id];
+                if !skip_name {
+                    if let Some(name) = &ty.name {
+                        self.src.push_str("[`");
+                        self.src.push_str(name);
+                        self.src.push_str("`](#");
+                        self.src.push_str(&name.to_snake_case());
+                        self.src.push_str(")");
+                        return;
+                    }
+                }
+                match &ty.kind {
+                    TypeDefKind::Type(t) => self.print_ty(iface, t, false),
+                    TypeDefKind::Record(r) => {
+                        assert!(r.is_tuple());
+                        self.src.push_str("(");
+                        for (i, f) in r.fields.iter().enumerate() {
+                            if i > 0 {
+                                self.src.push_str(", ");
+                            }
+                            self.print_ty(iface, &f.ty, false);
+                        }
+                        self.src.push_str(")");
+                    }
+                    TypeDefKind::Variant(v) => {
+                        if v.is_bool() {
+                            self.src.push_str("`bool`");
+                        } else if let Some(t) = v.as_option() {
+                            self.src.push_str("option<");
+                            self.print_ty(iface, t, false);
+                            self.src.push_str(">");
+                        } else if let Some((ok, err)) = v.as_expected() {
+                            self.src.push_str("expected<");
+                            match ok {
+                                Some(t) => self.print_ty(iface, t, false),
+                                None => self.src.push_str("_"),
+                            }
+                            self.src.push_str(", ");
+                            match err {
+                                Some(t) => self.print_ty(iface, t, false),
+                                None => self.src.push_str("_"),
+                            }
+                            self.src.push_str(">");
+                        } else {
+                            unreachable!()
+                        }
+                    }
+                    TypeDefKind::List(Type::Char) => self.src.push_str("`string`"),
+                    TypeDefKind::List(t) => {
+                        self.src.push_str("list<");
+                        self.print_ty(iface, t, false);
+                        self.src.push_str(">");
+                    }
+                    TypeDefKind::PushBuffer(t) => {
+                        self.src.push_str("push-buffer<");
+                        self.print_ty(iface, t, false);
+                        self.src.push_str(">");
+                    }
+                    TypeDefKind::PullBuffer(t) => {
+                        self.src.push_str("pull-buffer<");
+                        self.print_ty(iface, t, false);
+                        self.src.push_str(">");
+                    }
+                    TypeDefKind::Pointer(t) => {
+                        self.src.push_str("pointer<");
+                        self.print_ty(iface, t, false);
+                        self.src.push_str(">");
+                    }
+                    TypeDefKind::ConstPointer(t) => {
+                        self.src.push_str("const-pointer<");
+                        self.print_ty(iface, t, false);
+                        self.src.push_str(">");
+                    }
+                }
+            }
+        }
+    }
+
+    fn docs(&mut self, docs: &Docs) {
+        let docs = match &docs.contents {
+            Some(docs) => docs,
+            None => return,
+        };
+        for line in docs.lines() {
+            self.src.push_str(line.trim());
+            self.src.push_str("\n");
+        }
+    }
+
+    fn print_type_header(&mut self, name: &str) {
+        if self.types == 0 {
+            self.src.push_str("# Types\n\n");
+        }
+        self.types += 1;
+        self.src.push_str(&format!(
+            "## <a href=\"#{}\" name=\"{0}\"></a> `{}`: ",
+            name.to_snake_case(),
+            name,
+        ));
+        self.hrefs
+            .insert(name.to_string(), format!("#{}", name.to_snake_case()));
+    }
+
+    fn print_type_info(&mut self, ty: TypeId, docs: &Docs) {
+        self.docs(docs);
+        self.src.push_str("\n");
+        self.src
+            .push_str(&format!("Size: {}, ", self.sizes.size(&Type::Id(ty))));
+        self.src
+            .push_str(&format!("Alignment: {}\n", self.sizes.align(&Type::Id(ty))));
+    }
+}
+
+impl Generator for Markdown {
+    fn preprocess(&mut self, iface: &Interface, dir: Direction) {
+        self.sizes.fill(dir, iface);
+    }
+
+    fn type_record(
+        &mut self,
+        iface: &Interface,
+        id: TypeId,
+        name: &str,
+        record: &Record,
+        docs: &Docs,
+    ) {
+        self.print_type_header(name);
+        self.src.push_str("record\n\n");
+        self.print_type_info(id, docs);
+        self.src.push_str("\n### Record Fields\n\n");
+        for (i, field) in record.fields.iter().enumerate() {
+            self.src.push_str(&format!(
+                "- <a href=\"{r}.{f}\" name=\"{r}.{f}\"></a> [`{name}`](#{r}.{f}): ",
+                r = name.to_snake_case(),
+                f = field.name.to_snake_case(),
+                name = field.name,
+            ));
+            self.hrefs.insert(
+                format!("{}::{}", name, field.name),
+                format!("#{}.{}", name.to_snake_case(), field.name.to_snake_case()),
+            );
+            self.print_ty(iface, &field.ty, false);
+            self.src.indent(1);
+            self.src.push_str("\n\n");
+            self.docs(&field.docs);
+            self.src.deindent(1);
+            if record.is_flags() {
+                self.src.push_str(&format!("Bit: {}\n", i));
+            }
+            self.src.push_str("\n");
+        }
+    }
+
+    fn type_variant(
+        &mut self,
+        iface: &Interface,
+        id: TypeId,
+        name: &str,
+        variant: &Variant,
+        docs: &Docs,
+    ) {
+        self.print_type_header(name);
+        self.src.push_str("variant\n\n");
+        self.print_type_info(id, docs);
+        self.src.push_str("\n### Variant Cases\n\n");
+        for case in variant.cases.iter() {
+            self.src.push_str(&format!(
+                "- <a href=\"{v}.{c}\" name=\"{v}.{c}\"></a> [`{name}`](#{v}.{c})",
+                v = name.to_snake_case(),
+                c = case.name.to_snake_case(),
+                name = case.name,
+            ));
+            self.hrefs.insert(
+                format!("{}::{}", name, case.name),
+                format!("#{}.{}", name.to_snake_case(), case.name.to_snake_case()),
+            );
+            if let Some(ty) = &case.ty {
+                self.src.push_str(": ");
+                self.print_ty(iface, ty, false);
+            }
+            self.src.indent(1);
+            self.src.push_str("\n\n");
+            self.docs(&case.docs);
+            self.src.deindent(1);
+            self.src.push_str("\n");
+        }
+    }
+
+    fn type_resource(&mut self, iface: &Interface, ty: ResourceId) {
+        drop((iface, ty));
+    }
+
+    fn type_alias(&mut self, iface: &Interface, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
+        self.print_type_header(name);
+        self.print_ty(iface, ty, true);
+        self.src.push_str("\n\n");
+        self.print_type_info(id, docs);
+        self.src.push_str("\n");
+    }
+
+    fn type_list(&mut self, iface: &Interface, id: TypeId, name: &str, _ty: &Type, docs: &Docs) {
+        self.type_alias(iface, id, name, &Type::Id(id), docs);
+    }
+
+    fn type_pointer(
+        &mut self,
+        iface: &Interface,
+        id: TypeId,
+        name: &str,
+        _const: bool,
+        _ty: &Type,
+        docs: &Docs,
+    ) {
+        self.type_alias(iface, id, name, &Type::Id(id), docs);
+    }
+
+    fn type_builtin(&mut self, iface: &Interface, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
+        self.type_alias(iface, id, name, ty, docs)
+    }
+
+    fn type_push_buffer(
+        &mut self,
+        iface: &Interface,
+        id: TypeId,
+        name: &str,
+        _ty: &Type,
+        docs: &Docs,
+    ) {
+        self.type_alias(iface, id, name, &Type::Id(id), docs);
+    }
+
+    fn type_pull_buffer(
+        &mut self,
+        iface: &Interface,
+        id: TypeId,
+        name: &str,
+        _ty: &Type,
+        docs: &Docs,
+    ) {
+        self.type_alias(iface, id, name, &Type::Id(id), docs);
+    }
+
+    fn import(&mut self, iface: &Interface, func: &Function) {
+        if self.funcs == 0 {
+            self.src.push_str("# Functions\n\n");
+        }
+        self.funcs += 1;
+
+        self.src.push_str("----\n\n");
+        self.src.push_str(&format!(
+            "#### <a href=\"#{0}\" name=\"{0}\"></a> `",
+            func.name.to_snake_case()
+        ));
+        self.hrefs
+            .insert(func.name.clone(), format!("#{}", func.name.to_snake_case()));
+        self.src.push_str(&func.name);
+        self.src.push_str("` ");
+        self.src.push_str("\n\n");
+        self.docs(&func.docs);
+
+        if func.params.len() > 0 {
+            self.src.push_str("##### Params\n\n");
+            for (name, ty) in func.params.iter() {
+                self.src.push_str(&format!(
+                    "- <a href=\"#{f}.{p}\" name=\"{f}.{p}\"></a> `{}`: ",
+                    name,
+                    f = func.name.to_snake_case(),
+                    p = name.to_snake_case(),
+                ));
+                self.print_ty(iface, ty, false);
+                self.src.push_str("\n");
+            }
+        }
+        if func.results.len() > 0 {
+            self.src.push_str("##### Results\n\n");
+            for (name, ty) in func.results.iter() {
+                self.src.push_str(&format!(
+                    "- <a href=\"#{f}.{p}\" name=\"{f}.{p}\"></a> `{}`: ",
+                    name,
+                    f = func.name.to_snake_case(),
+                    p = name.to_snake_case(),
+                ));
+                self.print_ty(iface, ty, false);
+                self.src.push_str("\n");
+            }
+        }
+
+        self.src.push_str("\n");
+    }
+
+    fn export(&mut self, iface: &Interface, func: &Function) {
+        self.import(iface, func);
+    }
+
+    fn finish(&mut self, _iface: &Interface, files: &mut Files) {
+        let parser = Parser::new(&self.src);
+        let mut events = Vec::new();
+        for event in parser {
+            if let Event::Code(code) = &event {
+                if let Some(dst) = self.hrefs.get(code.as_ref()) {
+                    let tag = Tag::Link(LinkType::Inline, dst.as_str().into(), "".into());
+                    events.push(Event::Start(tag.clone()));
+                    events.push(event.clone());
+                    events.push(Event::End(tag));
+                    continue;
+                }
+            }
+            events.push(event);
+        }
+        let mut html_output = String::new();
+        html::push_html(&mut html_output, events.into_iter());
+
+        files.push("bindings.md", self.src.as_bytes());
+        files.push("bindings.html", html_output.as_bytes());
+    }
+}

--- a/crates/witx2/src/ast/resolve.rs
+++ b/crates/witx2/src/ast/resolve.rs
@@ -507,11 +507,15 @@ impl Resolver {
         let mut docs = String::new();
         for doc in doc.docs.iter() {
             if doc.starts_with("//") {
-                docs.push_str(&doc[2..]);
+                docs.push_str(&doc[2..].trim_start_matches('/').trim());
+                docs.push_str("\n");
             } else {
                 assert!(doc.starts_with("/*"));
                 assert!(doc.ends_with("*/"));
-                docs.push_str(&doc[2..doc.len() - 2])
+                for line in doc[2..doc.len() - 2].lines() {
+                    docs.push_str(line);
+                    docs.push_str("\n");
+                }
             }
         }
         Docs {

--- a/src/bin/witx-bindgen.rs
+++ b/src/bin/witx-bindgen.rs
@@ -36,6 +36,12 @@ enum Command {
         #[structopt(flatten)]
         common: Common,
     },
+    Markdown {
+        #[structopt(flatten)]
+        opts: witx_bindgen_gen_markdown::Opts,
+        #[structopt(flatten)]
+        common: Common,
+    },
 }
 
 #[derive(Debug, StructOpt)]
@@ -63,6 +69,7 @@ fn main() -> Result<()> {
         Command::Wasmtime { opts, common } => (Box::new(opts.build()), common),
         Command::Js { opts, common } => (Box::new(opts.build()), common),
         Command::C { opts, common } => (Box::new(opts.build()), common),
+        Command::Markdown { opts, common } => (Box::new(opts.build()), common),
     };
 
     if !common.import && !common.export {


### PR DESCRIPTION
This commit adds a new generation mode for Markdown which can be used to
generate both a `bindings.md` as well as a `bindings.html`, rendered by
`pulldown-cmark`, for documenting `*.witx` interfaces. This is currently
intended to somewhat closely mirror the markdown support in the upstream
WASI repository. Currently, though, it's quite simple and will likely
see more improvements over time!