### PR TITLE
Match JS conventions for methods

### DIFF
--- a/crates/build-test-wasm/build.rs
+++ b/crates/build-test-wasm/build.rs
@@ -45,7 +45,9 @@ fn main() {
         );
         println!("cargo:rerun-if-changed=../../tests/host.witx");
         println!("cargo:rerun-if-changed=../../tests/wasm.witx");
-        println!("cargo:rerun-if-changed=c-impl.c");
+        println!("cargo:rerun-if-changed=imports.c");
+        println!("cargo:rerun-if-changed=exports.c");
+        println!("cargo:rerun-if-changed=invalid.c");
 
         for (file, contents) in host_files.iter() {
             let dst = out_dir.join(file);

--- a/crates/gen-js/tests/run.ts
+++ b/crates/gen-js/tests/run.ts
@@ -14,7 +14,7 @@ async function run() {
     wasi_snapshot_preview1: wasi.wasiImport,
   };
   let instance: WebAssembly.Instance | null = null;
-  imports.add_host_to_imports(importObj, host(), name => {
+  imports.addHostToImports(importObj, host(), name => {
     if (instance === null)
       throw new Error("instance not ready yet");
     return instance.exports[name];
@@ -24,7 +24,7 @@ async function run() {
   instance = wasmObj.instance;
   wasi.initialize(instance);
 
-  run_tests(wasmObj);
+  runTests(wasmObj);
 
   // test other methods of creating a wasm wrapper
   (new exports.Wasm()).instantiate(wasm.buffer, importObj);
@@ -32,50 +32,50 @@ async function run() {
   (new exports.Wasm()).instantiate(new WebAssembly.Module(wasm), importObj);
   {
     const obj = new exports.Wasm();
-    obj.add_to_imports(importObj);
+    obj.addToImports(importObj);
     obj.instantiate(new WebAssembly.Instance(new WebAssembly.Module(wasm), importObj));
   }
 }
 
 function host(): imports.Host {
   let scalar = 0;
-  let saw_close = false;
+  let sawClose = false;
   return {
-    roundtrip_u8(x) { return x; },
-    roundtrip_s8(x) { return x; },
-    roundtrip_u16(x) { return x; },
-    roundtrip_s16(x) { return x; },
-    roundtrip_u32(x) { return x; },
-    roundtrip_s32(x) { return x; },
-    roundtrip_u64(x) { return x; },
-    roundtrip_s64(x) { return x; },
-    roundtrip_f32(x) { return x; },
-    roundtrip_f64(x) { return x; },
-    roundtrip_char(x) { return x; },
-    multiple_results() { return [4, 5]; },
-    set_scalar(x) { scalar = x; },
-    get_scalar() { return scalar; },
-    swap_tuple([a, b]) { return [b, a]; },
-    roundtrip_flags1(x) { return x; },
-    roundtrip_flags2(x) { return x; },
-    roundtrip_flags3(r0, r1, r2, r3) { return [r0, r1, r2, r3]; },
-    roundtrip_record1(x) { return x; },
+    roundtripU8(x) { return x; },
+    roundtripS8(x) { return x; },
+    roundtripU16(x) { return x; },
+    roundtripS16(x) { return x; },
+    roundtripU32(x) { return x; },
+    roundtripS32(x) { return x; },
+    roundtripU64(x) { return x; },
+    roundtripS64(x) { return x; },
+    roundtripF32(x) { return x; },
+    roundtripF64(x) { return x; },
+    roundtripChar(x) { return x; },
+    multipleResults() { return [4, 5]; },
+    setScalar(x) { scalar = x; },
+    getScalar() { return scalar; },
+    swapTuple([a, b]) { return [b, a]; },
+    roundtripFlags1(x) { return x; },
+    roundtripFlags2(x) { return x; },
+    roundtripFlags3(r0, r1, r2, r3) { return [r0, r1, r2, r3]; },
+    roundtripRecord1(x) { return x; },
     tuple0([]) { return []; },
     tuple1([x]) { return [x]; },
-    roundtrip_option(x) { return x; },
-    roundtrip_result(x) {
+    roundtripOption(x) { return x; },
+    roundtripResult(x) {
       if (x.tag == 'ok') {
         return { tag: 'ok', val: x.val };
       } else {
         return { tag: 'err', val: Math.round(x.val) };
       }
     },
-    roundtrip_enum(x) { return x; },
-    invert_bool(x) { return !x; },
-    variant_casts(x) { return x; },
-    variant_zeros(x) { return x; },
-    variant_typedefs(x, y, z) {},
-    variant_enums(a, b, c) {
+    roundtripEnum(x) { return x; },
+    invertBool(x) { return !x; },
+    variantCasts(x) { return x; },
+    variantZeros(x) { return x; },
+    variantTypedefs(x, y, z) {},
+    variantEnums(a, b, c) {
       assert.deepStrictEqual(a, true);
       assert.deepStrictEqual(b, { tag: 'ok' });
       assert.deepStrictEqual(c, imports.MyErrno.Success);
@@ -85,45 +85,45 @@ function host(): imports.Host {
         imports.MyErrno.A,
       ];
     },
-    list_param(a) {
+    listParam(a) {
       assert.deepStrictEqual(Array.from(a), [1, 2, 3, 4]);
     },
-    list_param2(a) {
+    listParam2(a) {
       assert.strictEqual(a, 'foo');
     },
-    list_param3(a) {
+    listParam3(a) {
       assert.deepStrictEqual(a, ['foo', 'bar', 'baz']);
     },
-    list_param4(a) {
+    listParam4(a) {
       assert.deepStrictEqual(a, [['foo', 'bar'], ['baz']]);
     },
-    list_result() {
+    listResult() {
       return new Uint8Array([1, 2, 3, 4, 5]);
     },
-    list_result2() { return 'hello!'; },
-    list_result3() { return ['hello,', 'world!']; },
-    string_roundtrip(x) { return x; },
-    host_state_create() { return 100; },
-    host_state_get(x) { return x as number; },
-    host_state2_create() { return 101; },
-    host_state2_saw_close() { return saw_close; },
-    drop_host_state2(state) { saw_close = true; },
-    two_host_states(a, b) { return [b, a]; },
-    host_state2_param_record(x) {},
-    host_state2_param_tuple(x) {},
-    host_state2_param_option(x) {},
-    host_state2_param_result(x) {},
-    host_state2_param_variant(x) {},
-    host_state2_param_list(x) {},
+    listResult2() { return 'hello!'; },
+    listResult3() { return ['hello,', 'world!']; },
+    stringRoundtrip(x) { return x; },
+    hostStateCreate() { return 100; },
+    hostStateGet(x) { return x as number; },
+    hostState2Create() { return 101; },
+    hostState2SawClose() { return sawClose; },
+    dropHostState2(state) { sawClose = true; },
+    twoHostStates(a, b) { return [b, a]; },
+    hostState2ParamRecord(x) {},
+    hostState2ParamTuple(x) {},
+    hostState2ParamOption(x) {},
+    hostState2ParamResult(x) {},
+    hostState2ParamVariant(x) {},
+    hostState2ParamList(x) {},
 
-    host_state2_result_record() { return { a: {} }; },
-    host_state2_result_tuple() { return [{}]; },
-    host_state2_result_option() { return 102; },
-    host_state2_result_result() { return { tag: 'ok', val: {} }; },
-    host_state2_result_variant() { return { tag: '0', val: {} }; },
-    host_state2_result_list() { return [{}, 3]; },
+    hostState2ResultRecord() { return { a: {} }; },
+    hostState2ResultTuple() { return [{}]; },
+    hostState2ResultOption() { return 102; },
+    hostState2ResultResult() { return { tag: 'ok', val: {} }; },
+    hostState2ResultVariant() { return { tag: '0', val: {} }; },
+    hostState2ResultList() { return [{}, 3]; },
 
-    buffer_u8(x, out) {
+    bufferU8(x, out) {
       assert.deepStrictEqual(Array.from(x), [0]);
       assert.deepStrictEqual(out.length, 10);
       out[0] = 1;
@@ -131,7 +131,7 @@ function host(): imports.Host {
       out[2] = 3;
       return 3;
     },
-    buffer_u32(x, out) {
+    bufferU32(x, out) {
       assert.deepStrictEqual(Array.from(x), [0]);
       assert.deepStrictEqual(out.length, 10);
       out[0] = 1;
@@ -139,7 +139,7 @@ function host(): imports.Host {
       out[2] = 3;
       return 3;
     },
-    buffer_bool(x, out) {
+    bufferBool(x, out) {
       assert.ok(x.length <= out.length);
       let amt = 0;
       while (true) {
@@ -151,7 +151,7 @@ function host(): imports.Host {
       }
       return amt;
     },
-    buffer_mutable1(x) {
+    bufferMutable1(x) {
       assert.strictEqual(x.length, 1);
       assert.strictEqual(x[0].length, 5);
       assert.strictEqual(x[0].pull(), true);
@@ -161,13 +161,13 @@ function host(): imports.Host {
       assert.strictEqual(x[0].pull(), false);
       assert.strictEqual(x[0].pull(), undefined);
     },
-    buffer_mutable2(x) {
+    bufferMutable2(x) {
       assert.strictEqual(x.length, 1);
       assert.ok(x[0].length > 4);
       x[0].set([1, 2, 3, 4]);
       return 4;
     },
-    buffer_mutable3(x) {
+    bufferMutable3(x) {
       assert.strictEqual(x.length, 1);
       assert.ok(x[0].length > 3);
       x[0].push(false);
@@ -175,38 +175,38 @@ function host(): imports.Host {
       x[0].push(false);
       return 3;
     },
-    buffer_in_record(x) { },
-    buffer_typedef(a, b, c, d) {},
+    bufferInRecord(x) { },
+    bufferTypedef(a, b, c, d) {},
 
-    list_in_record1(x) {},
-    list_in_record2() { return { a: 'list_in_record2' }; },
-    list_in_record3(x) {
+    listInRecord1(x) {},
+    listInRecord2() { return { a: 'list_in_record2' }; },
+    listInRecord3(x) {
       assert.strictEqual(x.a, 'list_in_record3 input');
       return { a: 'list_in_record3 output' };
     },
-    list_in_record4(x) {
+    listInRecord4(x) {
       assert.strictEqual(x.a, 'input4');
       return { a: 'result4' };
     },
-    list_in_variant1(a, b, c) {
+    listInVariant1(a, b, c) {
       assert.strictEqual(a, 'foo');
       assert.deepStrictEqual(b, { tag: 'err', val: 'bar' });
       assert.deepStrictEqual(c, { tag: '0', val: 'baz' });
     },
-    list_in_variant2() { return 'list_in_variant2'; },
-    list_in_variant3(x) {
+    listInVariant2() { return 'list_in_variant2'; },
+    listInVariant3(x) {
       assert.strictEqual(x, 'input3');
       return 'output3';
     },
 
-    errno_result() { return { tag: 'err', val: imports.MyErrno.B }; },
-    list_typedefs(x, y) {
+    errnoResult() { return { tag: 'err', val: imports.MyErrno.B }; },
+    listTypedefs(x, y) {
       assert.strictEqual(x, 'typedef1');
       assert.deepStrictEqual(y, ['typedef2']);
       return [(new TextEncoder).encode('typedef3'), ['typedef4']];
     },
 
-    list_of_variants(bools, results, enums) {
+    listOfVariants(bools, results, enums) {
       assert.deepStrictEqual(bools, [true, false]);
       assert.deepStrictEqual(results, [{ tag: 'ok' }, { tag: 'err' }]);
       assert.deepStrictEqual(enums, [imports.MyErrno.Success, imports.MyErrno.A]);
@@ -217,14 +217,14 @@ function host(): imports.Host {
       ];
     },
 
-    unaligned_roundtrip1(u16, u32, u64, flag32, flag64) {
+    unalignedRoundtrip1(u16, u32, u64, flag32, flag64) {
       assert.deepStrictEqual(Array.from(u16), [1]);
       assert.deepStrictEqual(Array.from(u32), [2]);
       assert.deepStrictEqual(Array.from(u64), [3n]);
       assert.deepStrictEqual(flag32, [imports.FLAG32_B8]);
       assert.deepStrictEqual(flag64, [imports.FLAG64_B9]);
     },
-    unaligned_roundtrip2(record, f32, f64, string, list) {
+    unalignedRoundtrip2(record, f32, f64, string, list) {
       assert.deepStrictEqual(Array.from(record), [{ a: 10, b: 11n }]);
       assert.deepStrictEqual(Array.from(f32), [100]);
       assert.deepStrictEqual(Array.from(f64), [101]);
@@ -232,7 +232,7 @@ function host(): imports.Host {
       assert.deepStrictEqual(list, [new Uint8Array([102])]);
     },
 
-    markdown2_create() {
+    markdown2Create() {
       class Markdown {
         buf: string;
 
@@ -252,93 +252,93 @@ function host(): imports.Host {
   };
 }
 
-function run_tests(wasm: exports.Wasm) {
-  const bytes = wasm.allocated_bytes();
-  wasm.run_import_tests();
+function runTests(wasm: exports.Wasm) {
+  const bytes = wasm.allocatedBytes();
+  wasm.runImportTests();
   test_scalars(wasm);
   test_records(wasm);
   test_variants(wasm);
-  test_lists(wasm);
-  test_flavorful(wasm);
+  testLists(wasm);
+  testFlavorful(wasm);
   test_invalid(wasm);
-  test_handles(wasm);
+  testHandles(wasm);
   // buffers(wasm);
 
   // Ensure that we properly called `free` everywhere in all the glue that we
   // needed to.
-  assert.strictEqual(bytes, wasm.allocated_bytes());
+  assert.strictEqual(bytes, wasm.allocatedBytes());
 }
 
 function test_scalars(wasm: exports.Wasm) {
-  assert.strictEqual(wasm.roundtrip_u8(1), 1);
-  assert.strictEqual(wasm.roundtrip_u8((1 << 8) - 1), (1 << 8) - 1);
+  assert.strictEqual(wasm.roundtripU8(1), 1);
+  assert.strictEqual(wasm.roundtripU8((1 << 8) - 1), (1 << 8) - 1);
 
-  assert.strictEqual(wasm.roundtrip_s8(1), 1);
-  assert.strictEqual(wasm.roundtrip_s8((1 << 7) - 1), (1 << 7) - 1);
-  assert.strictEqual(wasm.roundtrip_s8(-(1 << 7)), -(1 << 7));
+  assert.strictEqual(wasm.roundtripS8(1), 1);
+  assert.strictEqual(wasm.roundtripS8((1 << 7) - 1), (1 << 7) - 1);
+  assert.strictEqual(wasm.roundtripS8(-(1 << 7)), -(1 << 7));
 
-  assert.strictEqual(wasm.roundtrip_u16(1), 1);
-  assert.strictEqual(wasm.roundtrip_u16((1 << 16) - 1), (1 << 16) - 1);
+  assert.strictEqual(wasm.roundtripU16(1), 1);
+  assert.strictEqual(wasm.roundtripU16((1 << 16) - 1), (1 << 16) - 1);
 
-  assert.strictEqual(wasm.roundtrip_s16(1), 1);
-  assert.strictEqual(wasm.roundtrip_s16((1 << 15) - 1), (1 << 15) - 1);
-  assert.strictEqual(wasm.roundtrip_s16(-(1 << 15)), -(1 << 15));
+  assert.strictEqual(wasm.roundtripS16(1), 1);
+  assert.strictEqual(wasm.roundtripS16((1 << 15) - 1), (1 << 15) - 1);
+  assert.strictEqual(wasm.roundtripS16(-(1 << 15)), -(1 << 15));
 
-  assert.strictEqual(wasm.roundtrip_u32(1), 1);
-  assert.strictEqual(wasm.roundtrip_u32((1 << 32) - 1), (1 << 32) - 1);
+  assert.strictEqual(wasm.roundtripU32(1), 1);
+  assert.strictEqual(wasm.roundtripU32((1 << 32) - 1), (1 << 32) - 1);
 
-  assert.strictEqual(wasm.roundtrip_s32(1), 1);
-  assert.strictEqual(wasm.roundtrip_s32(((1 << 31) - 1) >>> 0), ((1 << 31) - 1) >>> 0);
-  assert.strictEqual(wasm.roundtrip_s32(1 << 31), 1 << 31);
+  assert.strictEqual(wasm.roundtripS32(1), 1);
+  assert.strictEqual(wasm.roundtripS32(((1 << 31) - 1) >>> 0), ((1 << 31) - 1) >>> 0);
+  assert.strictEqual(wasm.roundtripS32(1 << 31), 1 << 31);
 
-  assert.strictEqual(wasm.roundtrip_u64(1n), 1n);
-  assert.strictEqual(wasm.roundtrip_u64((1n << 64n) - 1n), (1n << 64n) - 1n);
+  assert.strictEqual(wasm.roundtripU64(1n), 1n);
+  assert.strictEqual(wasm.roundtripU64((1n << 64n) - 1n), (1n << 64n) - 1n);
 
-  assert.strictEqual(wasm.roundtrip_s64(1n), 1n);
-  assert.strictEqual(wasm.roundtrip_s64((1n << 63n) - 1n), (1n << 63n) - 1n);
-  assert.strictEqual(wasm.roundtrip_s64(-(1n << 63n)), -(1n << 63n));
+  assert.strictEqual(wasm.roundtripS64(1n), 1n);
+  assert.strictEqual(wasm.roundtripS64((1n << 63n) - 1n), (1n << 63n) - 1n);
+  assert.strictEqual(wasm.roundtripS64(-(1n << 63n)), -(1n << 63n));
 
-  assert.deepEqual(wasm.multiple_results(), [100, 200]);
+  assert.deepEqual(wasm.multipleResults(), [100, 200]);
 
-  assert.strictEqual(wasm.roundtrip_f32(1), 1);
-  assert.strictEqual(wasm.roundtrip_f32(Infinity), Infinity);
-  assert.strictEqual(wasm.roundtrip_f32(-Infinity), -Infinity);
-  assert.ok(Number.isNaN(wasm.roundtrip_f32(NaN)));
+  assert.strictEqual(wasm.roundtripF32(1), 1);
+  assert.strictEqual(wasm.roundtripF32(Infinity), Infinity);
+  assert.strictEqual(wasm.roundtripF32(-Infinity), -Infinity);
+  assert.ok(Number.isNaN(wasm.roundtripF32(NaN)));
 
-  assert.strictEqual(wasm.roundtrip_f64(1), 1);
-  assert.strictEqual(wasm.roundtrip_f64(Infinity), Infinity);
-  assert.strictEqual(wasm.roundtrip_f64(-Infinity), -Infinity);
-  assert.ok(Number.isNaN(wasm.roundtrip_f64(NaN)));
+  assert.strictEqual(wasm.roundtripF64(1), 1);
+  assert.strictEqual(wasm.roundtripF64(Infinity), Infinity);
+  assert.strictEqual(wasm.roundtripF64(-Infinity), -Infinity);
+  assert.ok(Number.isNaN(wasm.roundtripF64(NaN)));
 
-  assert.strictEqual(wasm.roundtrip_char('a'), 'a');
-  assert.strictEqual(wasm.roundtrip_char(' '), ' ');
-  assert.strictEqual(wasm.roundtrip_char('🚩'), '🚩');
+  assert.strictEqual(wasm.roundtripChar('a'), 'a');
+  assert.strictEqual(wasm.roundtripChar(' '), ' ');
+  assert.strictEqual(wasm.roundtripChar('🚩'), '🚩');
 
-  wasm.set_scalar(2);
-  assert.strictEqual(wasm.get_scalar(), 2);
-  wasm.set_scalar(4);
-  assert.strictEqual(wasm.get_scalar(), 4);
+  wasm.setScalar(2);
+  assert.strictEqual(wasm.getScalar(), 2);
+  wasm.setScalar(4);
+  assert.strictEqual(wasm.getScalar(), 4);
 }
 
 function test_records(wasm: exports.Wasm) {
-  assert.deepStrictEqual(wasm.swap_tuple([1, 2]), [2, 1]);
-  assert.deepEqual(wasm.roundtrip_flags1(exports.F1_A), exports.F1_A);
-  assert.deepEqual(wasm.roundtrip_flags1(0), 0);
-  assert.deepEqual(wasm.roundtrip_flags1(exports.F1_A | exports.F1_B), exports.F1_A | exports.F1_B);
+  assert.deepStrictEqual(wasm.swapTuple([1, 2]), [2, 1]);
+  assert.deepEqual(wasm.roundtripFlags1(exports.F1_A), exports.F1_A);
+  assert.deepEqual(wasm.roundtripFlags1(0), 0);
+  assert.deepEqual(wasm.roundtripFlags1(exports.F1_A | exports.F1_B), exports.F1_A | exports.F1_B);
 
-  assert.deepEqual(wasm.roundtrip_flags2(exports.F2_C), exports.F2_C);
-  assert.deepEqual(wasm.roundtrip_flags2(0), 0);
-  assert.deepEqual(wasm.roundtrip_flags2(exports.F2_D), exports.F2_D);
-  assert.deepEqual(wasm.roundtrip_flags2(exports.F2_C | exports.F2_E), exports.F2_C | exports.F2_E);
+  assert.deepEqual(wasm.roundtripFlags2(exports.F2_C), exports.F2_C);
+  assert.deepEqual(wasm.roundtripFlags2(0), 0);
+  assert.deepEqual(wasm.roundtripFlags2(exports.F2_D), exports.F2_D);
+  assert.deepEqual(wasm.roundtripFlags2(exports.F2_C | exports.F2_E), exports.F2_C | exports.F2_E);
 
   {
-    const { a, b } = wasm.roundtrip_record1({ a: 8, b: 0 });
+    const { a, b } = wasm.roundtripRecord1({ a: 8, b: 0 });
     assert.deepEqual(a, 8);
     assert.deepEqual(b, 0);
   }
 
   {
-    const { a, b } = wasm.roundtrip_record1({ a: 0, b: exports.F1_A | exports.F1_B });
+    const { a, b } = wasm.roundtripRecord1({ a: 0, b: exports.F1_A | exports.F1_B });
     assert.deepEqual(a, 0);
     assert.deepEqual(b, exports.F1_A | exports.F1_B);
   }
@@ -348,19 +348,19 @@ function test_records(wasm: exports.Wasm) {
 }
 
 function test_variants(wasm: exports.Wasm) {
-  assert.deepStrictEqual(wasm.roundtrip_option(1), 1);
-  assert.deepStrictEqual(wasm.roundtrip_option(null), null);
-  assert.deepStrictEqual(wasm.roundtrip_option(2), 2);
-  assert.deepStrictEqual(wasm.roundtrip_result({ tag: 'ok', val: 2 }), { tag: 'ok', val: 2 });
-  assert.deepStrictEqual(wasm.roundtrip_result({ tag: 'ok', val: 4 }), { tag: 'ok', val: 4 });
+  assert.deepStrictEqual(wasm.roundtripOption(1), 1);
+  assert.deepStrictEqual(wasm.roundtripOption(null), null);
+  assert.deepStrictEqual(wasm.roundtripOption(2), 2);
+  assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 2 }), { tag: 'ok', val: 2 });
+  assert.deepStrictEqual(wasm.roundtripResult({ tag: 'ok', val: 4 }), { tag: 'ok', val: 4 });
   const f = Math.fround(5.2);
-  assert.deepStrictEqual(wasm.roundtrip_result({ tag: 'err', val: f }), { tag: 'err', val: 5 });
+  assert.deepStrictEqual(wasm.roundtripResult({ tag: 'err', val: f }), { tag: 'err', val: 5 });
 
-  assert.deepStrictEqual(wasm.roundtrip_enum(exports.E1.A), exports.E1.A);
-  assert.deepStrictEqual(wasm.roundtrip_enum(exports.E1.B), exports.E1.B);
+  assert.deepStrictEqual(wasm.roundtripEnum(exports.E1.A), exports.E1.A);
+  assert.deepStrictEqual(wasm.roundtripEnum(exports.E1.B), exports.E1.B);
 
-  assert.deepStrictEqual(wasm.invert_bool(true), false);
-  assert.deepStrictEqual(wasm.invert_bool(false), true);
+  assert.deepStrictEqual(wasm.invertBool(true), false);
+  assert.deepStrictEqual(wasm.invertBool(false), true);
 
   {
     const a: exports.E1.A = exports.E1.A;
@@ -368,7 +368,7 @@ function test_variants(wasm: exports.Wasm) {
   }
 
   {
-    const [a1, a2, a3, a4, a5, a6] = wasm.variant_casts([
+    const [a1, a2, a3, a4, a5, a6] = wasm.variantCasts([
       { tag: 'a', val: 1 },
       { tag: 'a', val: 2 },
       { tag: 'a', val: 3 },
@@ -384,7 +384,7 @@ function test_variants(wasm: exports.Wasm) {
     assert.deepStrictEqual(a6, { tag: 'a', val: 6 });
   }
   {
-    const [b1, b2, b3, b4, b5, b6] = wasm.variant_casts([
+    const [b1, b2, b3, b4, b5, b6] = wasm.variantCasts([
       { tag: 'b', val: 1n },
       { tag: 'b', val: 2 },
       { tag: 'b', val: 3 },
@@ -401,7 +401,7 @@ function test_variants(wasm: exports.Wasm) {
   }
 
   {
-    const [a1, a2, a3, a4] = wasm.variant_zeros([
+    const [a1, a2, a3, a4] = wasm.variantZeros([
       { tag: 'a', val: 1 },
       { tag: 'a', val: 2n },
       { tag: 'a', val: 3 },
@@ -413,103 +413,103 @@ function test_variants(wasm: exports.Wasm) {
     assert.deepStrictEqual(a4, { tag: 'a', val: 4 });
   }
 
-  wasm.variant_typedefs(null, false, { tag: 'err' });
+  wasm.variantTypedefs(null, false, { tag: 'err' });
 }
 
-function test_lists(wasm: exports.Wasm) {
-    wasm.list_param(new Uint8Array([1, 2, 3, 4]));
-    wasm.list_param2("foo");
-    wasm.list_param3(["foo", "bar", "baz"]);
-    wasm.list_param4([["foo", "bar"], ["baz"]]);
-    assert.deepStrictEqual(Array.from(wasm.list_result()), [1, 2, 3, 4, 5]);
-    assert.deepStrictEqual(wasm.list_result2(), "hello!");
-    assert.deepStrictEqual(wasm.list_result3(), ["hello,", "world!"]);
+function testLists(wasm: exports.Wasm) {
+    wasm.listParam(new Uint8Array([1, 2, 3, 4]));
+    wasm.listParam2("foo");
+    wasm.listParam3(["foo", "bar", "baz"]);
+    wasm.listParam4([["foo", "bar"], ["baz"]]);
+    assert.deepStrictEqual(Array.from(wasm.listResult()), [1, 2, 3, 4, 5]);
+    assert.deepStrictEqual(wasm.listResult2(), "hello!");
+    assert.deepStrictEqual(wasm.listResult3(), ["hello,", "world!"]);
 
-    assert.deepStrictEqual(wasm.string_roundtrip("x"), "x");
-    assert.deepStrictEqual(wasm.string_roundtrip(""), "");
-    assert.deepStrictEqual(wasm.string_roundtrip("hello ⚑ world"), "hello ⚑ world");
+    assert.deepStrictEqual(wasm.stringRoundtrip("x"), "x");
+    assert.deepStrictEqual(wasm.stringRoundtrip(""), "");
+    assert.deepStrictEqual(wasm.stringRoundtrip("hello ⚑ world"), "hello ⚑ world");
 }
 
-function test_flavorful(wasm: exports.Wasm) {
-  wasm.list_in_record1({ a: "list_in_record1" });
-  assert.deepStrictEqual(wasm.list_in_record2(), { a: "list_in_record2" });
+function testFlavorful(wasm: exports.Wasm) {
+  wasm.listInRecord1({ a: "list_in_record1" });
+  assert.deepStrictEqual(wasm.listInRecord2(), { a: "list_in_record2" });
 
   assert.deepStrictEqual(
-    wasm.list_in_record3({ a: "list_in_record3 input" }),
+    wasm.listInRecord3({ a: "list_in_record3 input" }),
     { a: "list_in_record3 output" },
   );
 
   assert.deepStrictEqual(
-    wasm.list_in_record4({ a: "input4" }),
+    wasm.listInRecord4({ a: "input4" }),
     { a: "result4" },
   );
 
-  wasm.list_in_variant1("foo", { tag: 'err', val: 'bar' }, { tag: '0', val: 'baz' });
+  wasm.listInVariant1("foo", { tag: 'err', val: 'bar' }, { tag: '0', val: 'baz' });
 
-  assert.deepStrictEqual(wasm.list_in_variant2(), "list_in_variant2");
-  assert.deepStrictEqual(wasm.list_in_variant3("input3"), "output3");
+  assert.deepStrictEqual(wasm.listInVariant2(), "list_in_variant2");
+  assert.deepStrictEqual(wasm.listInVariant3("input3"), "output3");
 
-  assert.deepStrictEqual(wasm.errno_result().tag, 'err');
+  assert.deepStrictEqual(wasm.errnoResult().tag, 'err');
 
-  const [r1, r2] = wasm.list_typedefs("typedef1", ["typedef2"]);
+  const [r1, r2] = wasm.listTypedefs("typedef1", ["typedef2"]);
   assert.deepStrictEqual(r1, (new TextEncoder()).encode('typedef3'));
   assert.deepStrictEqual(r2, ['typedef4']);
 }
 
-function test_handles(wasm: exports.Wasm) {
-  const bytes = wasm.allocated_bytes();
+function testHandles(wasm: exports.Wasm) {
+  const bytes = wasm.allocatedBytes();
 
   // Param/result of a handle works in a simple fashion
-  const s: exports.WasmState = wasm.wasm_state_create();
-  assert.strictEqual(wasm.wasm_state_get_val(s), 100);
+  const s: exports.WasmState = wasm.wasmStateCreate();
+  assert.strictEqual(wasm.wasmStateGetVal(s), 100);
 
   // Deterministic destruction is possible
-  assert.strictEqual(wasm.wasm_state2_saw_close(), false);
-  const s2: exports.WasmState2 = wasm.wasm_state2_create();
-  assert.strictEqual(wasm.wasm_state2_saw_close(), false);
+  assert.strictEqual(wasm.wasmState2SawClose(), false);
+  const s2: exports.WasmState2 = wasm.wasmState2Create();
+  assert.strictEqual(wasm.wasmState2SawClose(), false);
   s2.drop();
-  assert.strictEqual(wasm.wasm_state2_saw_close(), true);
+  assert.strictEqual(wasm.wasmState2SawClose(), true);
 
-  const arg1 = wasm.wasm_state_create();
-  const arg2 = wasm.wasm_state2_create();
-  const [c, d] = wasm.two_wasm_states(arg1, arg2);
+  const arg1 = wasm.wasmStateCreate();
+  const arg2 = wasm.wasmState2Create();
+  const [c, d] = wasm.twoWasmStates(arg1, arg2);
   arg1.drop();
   arg2.drop();
 
-  wasm.wasm_state2_param_record({ a: d });
-  wasm.wasm_state2_param_tuple([d]);
-  wasm.wasm_state2_param_option(d);
-  wasm.wasm_state2_param_option(null);
-  wasm.wasm_state2_param_result({ tag: 'ok', val: d });
-  wasm.wasm_state2_param_result({ tag: 'err', val: 2 });
-  wasm.wasm_state2_param_variant({ tag: '0', val: d });
-  wasm.wasm_state2_param_variant({ tag: '1', val: 2 });
-  wasm.wasm_state2_param_list([]);
-  wasm.wasm_state2_param_list([d]);
-  wasm.wasm_state2_param_list([d, d]);
+  wasm.wasmState2ParamRecord({ a: d });
+  wasm.wasmState2ParamTuple([d]);
+  wasm.wasmState2ParamOption(d);
+  wasm.wasmState2ParamOption(null);
+  wasm.wasmState2ParamResult({ tag: 'ok', val: d });
+  wasm.wasmState2ParamResult({ tag: 'err', val: 2 });
+  wasm.wasmState2ParamVariant({ tag: '0', val: d });
+  wasm.wasmState2ParamVariant({ tag: '1', val: 2 });
+  wasm.wasmState2ParamList([]);
+  wasm.wasmState2ParamList([d]);
+  wasm.wasmState2ParamList([d, d]);
 
   c.drop();
   d.drop();
 
-  wasm.wasm_state2_result_record().a.drop();
-  wasm.wasm_state2_result_tuple()[0].drop();
-  const opt = wasm.wasm_state2_result_option();
+  wasm.wasmState2ResultRecord().a.drop();
+  wasm.wasmState2ResultTuple()[0].drop();
+  const opt = wasm.wasmState2ResultOption();
   if (opt === null)
     throw new Error('should be some');
   opt.drop();
-  const result = wasm.wasm_state2_result_result();
+  const result = wasm.wasmState2ResultResult();
   if (result.tag === 'err')
     throw new Error('should be ok');
   result.val.drop();
-  const variant = wasm.wasm_state2_result_variant();
+  const variant = wasm.wasmState2ResultVariant();
   if (variant.tag === '1')
     throw new Error('should be 0');
   variant.val.drop();
-  for (let val of wasm.wasm_state2_result_list())
+  for (let val of wasm.wasmState2ResultList())
     val.drop();
 
   s.drop();
-  assert.strictEqual(bytes, wasm.allocated_bytes());
+  assert.strictEqual(bytes, wasm.allocatedBytes());
 
   const md = exports.Markdown.create(wasm);
   if (md) {

--- a/crates/test-codegen/src/lib.rs
+++ b/crates/test-codegen/src/lib.rs
@@ -1,6 +1,5 @@
 use ignore::gitignore::GitignoreBuilder;
 use proc_macro::{TokenStream, TokenTree};
-use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -36,6 +35,7 @@ pub fn rust_wasm_import(input: TokenStream) -> TokenStream {
 #[cfg(feature = "witx-bindgen-gen-rust-wasm")]
 pub fn rust_wasm_export(input: TokenStream) -> TokenStream {
     use heck::*;
+    use std::collections::BTreeMap;
     use witx2::{FunctionKind, Type, TypeDefKind};
 
     return gen_rust(

--- a/crates/witx-bindgen-demo/main.ts
+++ b/crates/witx-bindgen-demo/main.ts
@@ -49,7 +49,7 @@ class Editor {
       log: console.log,
       error: console.error,
     };
-    browser.add_browser_to_imports(imports, obj, name => this.demo.instance.exports[name]);
+    browser.addBrowserToImports(imports, obj, name => this.demo.instance.exports[name]);
     await this.demo.instantiate(fetch('./demo.wasm'), imports);
     this.config = Config.new(this.demo);
     this.installListeners();
@@ -68,12 +68,12 @@ class Editor {
     this.mode.addEventListener('change', () => this.render());
 
     this.rustUnchecked.addEventListener('change', () => {
-      this.config.set_rust_unchecked(this.rustUnchecked.checked);
+      this.config.setRustUnchecked(this.rustUnchecked.checked);
       this.render();
     });
 
     this.wasmtimeTracing.addEventListener('change', () => {
-      this.config.set_wasmtime_tracing(this.wasmtimeTracing.checked);
+      this.config.setWasmtimeTracing(this.wasmtimeTracing.checked);
       this.render();
     });
     this.wasmtimeAsync.addEventListener('change', () => {
@@ -82,11 +82,11 @@ class Editor {
         async_ = { tag: 'all' };
       else
         async_ = { tag: 'none' };
-      this.config.set_wasmtime_async(async_);
+      this.config.setWasmtimeAsync(async_);
       this.render();
     });
     this.wasmtimeCustomError.addEventListener('change', () => {
-      this.config.set_wasmtime_custom_error(this.wasmtimeCustomError.checked);
+      this.config.setWasmtimeCustomError(this.wasmtimeCustomError.checked);
       this.render();
     });
     this.files.addEventListener('change', () => this.updateSelectedFile());


### PR DESCRIPTION
JS doesn't use `snake_case` for methods, instead it uses `mixedCase`.