### PR TITLE
Initial commit of a wasmtime-py bindings generator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,10 @@ jobs:
     - name: Install NPM packages
       run: npm install
       working-directory: crates/gen-js
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - run: pip install mypy wasmtime
     - if: matrix.mode == 'release'
       name: Test release build
       run: cargo test --workspace --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,6 +1329,7 @@ dependencies = [
  "witx-bindgen-gen-js",
  "witx-bindgen-gen-rust-wasm",
  "witx-bindgen-gen-wasmtime",
+ "witx-bindgen-gen-wasmtime-py",
  "witx2",
 ]
 
@@ -1971,6 +1972,7 @@ dependencies = [
  "witx-bindgen-gen-markdown",
  "witx-bindgen-gen-rust-wasm",
  "witx-bindgen-gen-wasmtime",
+ "witx-bindgen-gen-wasmtime-py",
 ]
 
 [[package]]
@@ -1983,6 +1985,7 @@ dependencies = [
  "witx-bindgen-gen-markdown",
  "witx-bindgen-gen-rust-wasm",
  "witx-bindgen-gen-wasmtime",
+ "witx-bindgen-gen-wasmtime-py",
  "witx-bindgen-rust",
 ]
 
@@ -2055,6 +2058,17 @@ dependencies = [
  "witx-bindgen-gen-core",
  "witx-bindgen-gen-rust",
  "witx-bindgen-wasmtime",
+]
+
+[[package]]
+name = "witx-bindgen-gen-wasmtime-py"
+version = "0.1.0"
+dependencies = [
+ "build-test-wasm",
+ "heck",
+ "structopt",
+ "test-codegen",
+ "witx-bindgen-gen-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ structopt = { version = "0.3", default-features = false }
 witx-bindgen-gen-core = { path = 'crates/gen-core', features = ['old-witx-compat'] }
 witx-bindgen-gen-rust-wasm = { path = 'crates/gen-rust-wasm', features = ['structopt'] }
 witx-bindgen-gen-wasmtime = { path = 'crates/gen-wasmtime', features = ['structopt'] }
+witx-bindgen-gen-wasmtime-py = { path = 'crates/gen-wasmtime-py', features = ['structopt'] }
 witx-bindgen-gen-js = { path = 'crates/gen-js', features = ['structopt'] }
 witx-bindgen-gen-c = { path = 'crates/gen-c', features = ['structopt'] }
 witx-bindgen-gen-markdown = { path = 'crates/gen-markdown', features = ['structopt'] }

--- a/README.md
+++ b/README.md
@@ -119,11 +119,25 @@ to follow the canonical ABI for their exports/imports:
   other type-checkers.
 
 All generators support the `--import` and `--export` flags in the `witx-bindgen`
-CLI tool. Here "import" means "imported by WebAssembly" and "export" means
+CLI tool:
+
+```
+$ witx-bindgen js --import browser.witx
+$ witx-bindgen rust-wasm --export my-interface.witx
+$ witx-bindgen wasmtime --import host-functions.witx
+```
+
+Here "import" means "imported by WebAssembly" and "export" means
 "exported by WebAssembly". This means that wasm files import APIs with
 `--import`, whereas hosts provide imports to wasm modules using `--import` (the
 terminology here [can be
 confusing](https://github.com/bytecodealliance/witx-bindgen/issues/34)
+
+Finally in a sort of "miscellaneous" category the `witx-bindgen` CLI also
+supports:
+
+* `markdown` - generates a `*.md` and a `*.html` file with readable
+  documentation rendered from the comments in the source `*.witx` file.
 
 Note that the list of supported languages here is a snapshot in time and is not
 final. The purpose of the interface-types proposal is to be language agnostic

--- a/crates/build-test-wasm/imports.c
+++ b/crates/build-test-wasm/imports.c
@@ -2,6 +2,7 @@
 #include <host.h>
 #include <limits.h>
 #include <math.h>
+#include <float.h>
 #include <stdio.h>
 #include <string.h>
 #include <wasm.h>
@@ -382,6 +383,78 @@ static void test_lists() {
     assert(b.len == a.len);
     assert(memcmp(b.ptr, a.ptr, a.len) == 0);
     host_string_free(&b);
+  }
+
+  {
+    uint8_t u8[2] = {0, UCHAR_MAX};
+    int8_t s8[2] = {SCHAR_MIN, SCHAR_MAX};
+    host_list_u8_t list_u8 = { u8, 2 };
+    host_list_s8_t list_s8 = { s8, 2 };
+    host_list_u8_t list_u8_out;
+    host_list_s8_t list_s8_out;
+    host_list_minmax8(&list_u8, &list_s8, &list_u8_out, &list_s8_out);
+    assert(list_u8_out.len == 2 && list_u8_out.ptr[0] == 0 && list_u8_out.ptr[1] == UCHAR_MAX);
+    assert(list_s8_out.len == 2 && list_s8_out.ptr[0] == SCHAR_MIN && list_s8_out.ptr[1] == SCHAR_MAX);
+    host_list_u8_free(&list_u8_out);
+    host_list_s8_free(&list_s8_out);
+  }
+
+  {
+    uint16_t u16[2] = {0, USHRT_MAX};
+    int16_t s16[2] = {SHRT_MIN, SHRT_MAX};
+    host_list_u16_t list_u16 = { u16, 2 };
+    host_list_s16_t list_s16 = { s16, 2 };
+    host_list_u16_t list_u16_out;
+    host_list_s16_t list_s16_out;
+    host_list_minmax16(&list_u16, &list_s16, &list_u16_out, &list_s16_out);
+    assert(list_u16_out.len == 2 && list_u16_out.ptr[0] == 0 && list_u16_out.ptr[1] == USHRT_MAX);
+    assert(list_s16_out.len == 2 && list_s16_out.ptr[0] == SHRT_MIN && list_s16_out.ptr[1] == SHRT_MAX);
+    host_list_u16_free(&list_u16_out);
+    host_list_s16_free(&list_s16_out);
+  }
+
+  {
+    uint32_t u32[2] = {0, UINT_MAX};
+    int32_t s32[2] = {INT_MIN, INT_MAX};
+    host_list_u32_t list_u32 = { u32, 2 };
+    host_list_s32_t list_s32 = { s32, 2 };
+    host_list_u32_t list_u32_out;
+    host_list_s32_t list_s32_out;
+    host_list_minmax32(&list_u32, &list_s32, &list_u32_out, &list_s32_out);
+    assert(list_u32_out.len == 2 && list_u32_out.ptr[0] == 0 && list_u32_out.ptr[1] == UINT_MAX);
+    assert(list_s32_out.len == 2 && list_s32_out.ptr[0] == INT_MIN && list_s32_out.ptr[1] == INT_MAX);
+    host_list_u32_free(&list_u32_out);
+    host_list_s32_free(&list_s32_out);
+  }
+
+  {
+    uint64_t u64[2] = {0, ULLONG_MAX};
+    int64_t s64[2] = {LLONG_MIN, LLONG_MAX};
+    host_list_u64_t list_u64 = { u64, 2 };
+    host_list_s64_t list_s64 = { s64, 2 };
+    host_list_u64_t list_u64_out;
+    host_list_s64_t list_s64_out;
+    host_list_minmax64(&list_u64, &list_s64, &list_u64_out, &list_s64_out);
+    assert(list_u64_out.len == 2 && list_u64_out.ptr[0] == 0 && list_u64_out.ptr[1] == ULLONG_MAX);
+    assert(list_s64_out.len == 2 && list_s64_out.ptr[0] == LLONG_MIN && list_s64_out.ptr[1] == LLONG_MAX);
+    host_list_u64_free(&list_u64_out);
+    host_list_s64_free(&list_s64_out);
+  }
+
+  {
+    float f32[4] = {-FLT_MAX, FLT_MAX, -INFINITY, INFINITY};
+    double f64[4] = {-DBL_MAX, DBL_MAX, -INFINITY, INFINITY};
+    host_list_f32_t list_f32 = { f32, 4 };
+    host_list_f64_t list_f64 = { f64, 4 };
+    host_list_f32_t list_f32_out;
+    host_list_f64_t list_f64_out;
+    host_list_minmax_float(&list_f32, &list_f64, &list_f32_out, &list_f64_out);
+    assert(list_f32_out.len == 4 && list_f32_out.ptr[0] == -FLT_MAX && list_f32_out.ptr[1] == FLT_MAX);
+    assert(list_f32_out.ptr[2] == -INFINITY && list_f32_out.ptr[3] == INFINITY);
+    assert(list_f64_out.len == 4 && list_f64_out.ptr[0] == -DBL_MAX && list_f64_out.ptr[1] == DBL_MAX);
+    assert(list_f64_out.ptr[2] == -INFINITY && list_f64_out.ptr[3] == INFINITY);
+    host_list_f32_free(&list_f32_out);
+    host_list_f64_free(&list_f64_out);
   }
 }
 

--- a/crates/gen-c/src/lib.rs
+++ b/crates/gen-c/src/lib.rs
@@ -1512,7 +1512,10 @@ impl Bindgen for FunctionBindgen<'_> {
                     .blocks
                     .drain(self.blocks.len() - variant.cases.len()..)
                     .collect::<Vec<_>>();
-                let payload = self.payloads.pop().unwrap();
+                let payloads = self
+                    .payloads
+                    .drain(self.payloads.len() - variant.cases.len()..)
+                    .collect::<Vec<_>>();
 
                 if results.len() == 1 && variant.is_enum() {
                     results.push(format!("(int32_t) {}", operands[0]));
@@ -1538,8 +1541,8 @@ impl Bindgen for FunctionBindgen<'_> {
 
                 self.src
                     .push_str(&format!("switch ((int32_t) {}) {{\n", expr_to_match));
-                for (i, (case, (block, block_results))) in
-                    variant.cases.iter().zip(blocks).enumerate()
+                for (i, ((case, (block, block_results)), payload)) in
+                    variant.cases.iter().zip(blocks).zip(payloads).enumerate()
                 {
                     self.src.push_str(&format!("case {}: {{\n", i));
                     if let Some(ty) = &case.ty {

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -1544,8 +1544,9 @@ impl Bindgen for FunctionBindgen<'_> {
                             "const ptr{} = realloc(0, 0, {}, len{0} * {});\n",
                             tmp, align, size,
                         ));
+                        // TODO: this is the wrong endianness
                         self.src.js(&format!(
-                            "(new Uint8Array(memory.buffer, ptr{}, len{0} * {})).set(new Uint8Array(val{0}));\n",
+                            "(new Uint8Array(memory.buffer, ptr{}, len{0} * {})).set(new Uint8Array(val{0}.buffer));\n",
                             tmp, size,
                         ));
                     }
@@ -1572,6 +1573,7 @@ impl Bindgen for FunctionBindgen<'_> {
                         )
                     }
                     _ => {
+                        // TODO: this is the wrong endianness
                         let array_ty = self.gen.array_ty(iface, element).unwrap();
                         (
                             format!(
@@ -1677,6 +1679,7 @@ impl Bindgen for FunctionBindgen<'_> {
                 self.src
                     .js(&format!("const len{} = {};\n", tmp, operands[2]));
                 if let Some(ty) = self.gen.array_ty(iface, ty) {
+                    // TODO: this is the wrong endianness
                     results.push(format!("new {}(memory.buffer, ptr{}, len{1})", ty, tmp));
                 } else {
                     let size = self.gen.sizes.size(ty);
@@ -2038,7 +2041,6 @@ impl Js {
                 class Slab {
                     constructor() {
                         this.list = [];
-                        this.len = 0;
                         this.head = 0;
                     }
 

--- a/crates/gen-js/tests/run.ts
+++ b/crates/gen-js/tests/run.ts
@@ -249,18 +249,78 @@ function host(): imports.Host {
 
       return new Markdown();
     },
+
+    listMinmax8(u, s) {
+      assert.deepEqual(u.length, 2);
+      assert.deepEqual(u[0], 0);
+      assert.deepEqual(u[1], (1 << 8) - 1);
+      assert.deepEqual(s.length, 2);
+      assert.deepEqual(s[0], -(1 << 7));
+      assert.deepEqual(s[1], (1 << 7) - 1);
+
+      return [u, s];
+    },
+
+    listMinmax16(u, s) {
+      assert.deepEqual(u.length, 2);
+      assert.deepEqual(u[0], 0);
+      assert.deepEqual(u[1], (1 << 16) - 1);
+      assert.deepEqual(s.length, 2);
+      assert.deepEqual(s[0], -(1 << 15));
+      assert.deepEqual(s[1], (1 << 15) - 1);
+
+      return [u, s];
+    },
+
+    listMinmax32(u, s) {
+      assert.deepEqual(u.length, 2);
+      assert.deepEqual(u[0], 0);
+      assert.deepEqual(u[1], ~0 >>> 0);
+      assert.deepEqual(s.length, 2);
+      assert.deepEqual(s[0], 1 << 31);
+      assert.deepEqual(s[1], ((1 << 31) - 1) >>> 0);
+
+      return [u, s];
+    },
+
+    listMinmax64(u, s) {
+      assert.deepEqual(u.length, 2);
+      assert.deepEqual(u[0], 0n);
+      assert.deepEqual(u[1], (2n ** 64n) - 1n);
+      assert.deepEqual(s.length, 2);
+      assert.deepEqual(s[0], -(2n ** 63n));
+      assert.deepEqual(s[1], (2n ** 63n) - 1n);
+
+      return [u, s];
+    },
+
+    listMinmaxFloat(f, d) {
+      assert.deepEqual(f.length, 4);
+      assert.deepEqual(f[0], -3.4028234663852886e+38);
+      assert.deepEqual(f[1], 3.4028234663852886e+38);
+      assert.deepEqual(f[2], Number.NEGATIVE_INFINITY);
+      assert.deepEqual(f[3], Number.POSITIVE_INFINITY);
+
+      assert.deepEqual(d.length, 4);
+      assert.deepEqual(d[0], -Number.MAX_VALUE);
+      assert.deepEqual(d[1], Number.MAX_VALUE);
+      assert.deepEqual(d[2], Number.NEGATIVE_INFINITY);
+      assert.deepEqual(d[3], Number.POSITIVE_INFINITY);
+
+      return [f, d];
+    },
   };
 }
 
 function runTests(wasm: exports.Wasm) {
   const bytes = wasm.allocatedBytes();
   wasm.runImportTests();
-  test_scalars(wasm);
-  test_records(wasm);
-  test_variants(wasm);
+  testScalars(wasm);
+  testRecords(wasm);
+  testVariants(wasm);
   testLists(wasm);
   testFlavorful(wasm);
-  test_invalid(wasm);
+  testInvalid(wasm);
   testHandles(wasm);
   // buffers(wasm);
 
@@ -269,7 +329,7 @@ function runTests(wasm: exports.Wasm) {
   assert.strictEqual(bytes, wasm.allocatedBytes());
 }
 
-function test_scalars(wasm: exports.Wasm) {
+function testScalars(wasm: exports.Wasm) {
   assert.strictEqual(wasm.roundtripU8(1), 1);
   assert.strictEqual(wasm.roundtripU8((1 << 8) - 1), (1 << 8) - 1);
 
@@ -285,7 +345,7 @@ function test_scalars(wasm: exports.Wasm) {
   assert.strictEqual(wasm.roundtripS16(-(1 << 15)), -(1 << 15));
 
   assert.strictEqual(wasm.roundtripU32(1), 1);
-  assert.strictEqual(wasm.roundtripU32((1 << 32) - 1), (1 << 32) - 1);
+  assert.strictEqual(wasm.roundtripU32(~0 >>> 0), ~0 >>> 0);
 
   assert.strictEqual(wasm.roundtripS32(1), 1);
   assert.strictEqual(wasm.roundtripS32(((1 << 31) - 1) >>> 0), ((1 << 31) - 1) >>> 0);
@@ -320,7 +380,7 @@ function test_scalars(wasm: exports.Wasm) {
   assert.strictEqual(wasm.getScalar(), 4);
 }
 
-function test_records(wasm: exports.Wasm) {
+function testRecords(wasm: exports.Wasm) {
   assert.deepStrictEqual(wasm.swapTuple([1, 2]), [2, 1]);
   assert.deepEqual(wasm.roundtripFlags1(exports.F1_A), exports.F1_A);
   assert.deepEqual(wasm.roundtripFlags1(0), 0);
@@ -347,7 +407,7 @@ function test_records(wasm: exports.Wasm) {
   assert.deepStrictEqual(wasm.tuple1([1]), [1]);
 }
 
-function test_variants(wasm: exports.Wasm) {
+function testVariants(wasm: exports.Wasm) {
   assert.deepStrictEqual(wasm.roundtripOption(1), 1);
   assert.deepStrictEqual(wasm.roundtripOption(null), null);
   assert.deepStrictEqual(wasm.roundtripOption(2), 2);
@@ -582,7 +642,7 @@ function testHandles(wasm: exports.Wasm) {
 //     Ok(())
 // }
 
-function test_invalid(wasm: exports.Wasm) {
+function testInvalid(wasm: exports.Wasm) {
   const exports = wasm.instance.exports as any;
   assert.throws(exports.invalid_bool, /invalid variant discriminant for bool/);
   assert.throws(exports.invalid_u8, /must be between/);

--- a/crates/gen-wasmtime-py/Cargo.toml
+++ b/crates/gen-wasmtime-py/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "witx-bindgen-gen-wasmtime-py"
+version = "0.1.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+witx-bindgen-gen-core = { path = '../gen-core', version = '0.1.0' }
+heck = "0.3"
+structopt = { version = "0.3", default-features = false, optional = true }
+
+[dev-dependencies]
+build-test-wasm = { path = '../build-test-wasm' }
+test-codegen = { path = '../test-codegen', features = ['witx-bindgen-gen-wasmtime-py'] }
+
+[features]
+old-witx-compat = ['witx-bindgen-gen-core/old-witx-compat']

--- a/crates/gen-wasmtime-py/build.rs
+++ b/crates/gen-wasmtime-py/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    // this build script is currently only here so OUT_DIR is set for testing.
+}

--- a/crates/gen-wasmtime-py/mypy.ini
+++ b/crates/gen-wasmtime-py/mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+
+disallow_any_unimported = True
+
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+strict_optional = True
+
+warn_return_any = True
+warn_unused_configs = True

--- a/crates/gen-wasmtime-py/src/lib.rs
+++ b/crates/gen-wasmtime-py/src/lib.rs
@@ -1,0 +1,2266 @@
+use heck::*;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::mem;
+use witx_bindgen_gen_core::witx2::abi::{
+    Bindgen, Bitcast, Direction, Instruction, LiftLower, WasmType, WitxInstruction,
+};
+use witx_bindgen_gen_core::{witx2::*, Files, Generator, Ns};
+
+#[derive(Default)]
+pub struct WasmtimePy {
+    src: Source,
+    in_import: bool,
+    opts: Opts,
+    imports: HashMap<String, Imports>,
+    exports: HashMap<String, Exports>,
+    sizes: SizeAlign,
+    needs_clamp: bool,
+    needs_store: bool,
+    needs_load: bool,
+    needs_validate_guest_char: bool,
+    needs_expected: bool,
+    needs_i32_to_f32: bool,
+    needs_f32_to_i32: bool,
+    needs_i64_to_f64: bool,
+    needs_f64_to_i64: bool,
+    needs_decode_utf8: bool,
+    needs_encode_utf8: bool,
+    needs_list_canon_lift: bool,
+    needs_list_canon_lower: bool,
+    needs_push_buffer: bool,
+    needs_pull_buffer: bool,
+    needs_t_typevar: bool,
+    pyimports: BTreeMap<String, Option<BTreeSet<String>>>,
+}
+
+#[derive(Default)]
+struct Imports {
+    freestanding_funcs: Vec<Import>,
+    resource_funcs: BTreeMap<ResourceId, Vec<Import>>,
+}
+
+struct Import {
+    name: String,
+    src: Source,
+    wasm_ty: String,
+    pysig: String,
+}
+
+#[derive(Default)]
+struct Exports {
+    freestanding_funcs: Vec<Source>,
+    resource_funcs: BTreeMap<ResourceId, Vec<Source>>,
+    fields: BTreeMap<String, &'static str>,
+}
+
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+pub struct Opts {
+    #[cfg_attr(feature = "structopt", structopt(long = "no-typescript"))]
+    pub no_typescript: bool,
+}
+
+impl Opts {
+    pub fn build(self) -> WasmtimePy {
+        let mut r = WasmtimePy::new();
+        r.opts = self;
+        r
+    }
+}
+
+impl WasmtimePy {
+    pub fn new() -> WasmtimePy {
+        WasmtimePy::default()
+    }
+
+    fn indent(&mut self) {
+        self.src.indent(2);
+    }
+
+    fn deindent(&mut self) {
+        self.src.deindent(2);
+    }
+
+    fn print_intrinsics(&mut self, iface: &Interface) {
+        if self.needs_clamp {
+            self.src.push_str(
+                "
+                    def _clamp(i: int, min: int, max: int) -> int:
+                        if i < min or i > max:
+                            raise OverflowError(f'must be between {min} and {max}')
+                        return i
+                ",
+            );
+        }
+        if self.needs_store {
+            // TODO: this uses native endianness
+            self.pyimport("ctypes", None);
+            self.src.push_str(
+                "
+                    def _store(ty: Any, mem: wasmtime.Memory, store: wasmtime.Storelike, base: int, offset: int, val: Any) -> None:
+                        ptr = (base & 0xffffffff) + offset
+                        if ptr + ctypes.sizeof(ty) > mem.data_len(store):
+                            raise IndexError('out-of-bounds store')
+                        raw_base = mem.data_ptr(store)
+                        c_ptr = ctypes.POINTER(ty)(
+                            ty.from_address(ctypes.addressof(raw_base.contents) + ptr)
+                        )
+                        c_ptr[0] = val
+                ",
+            );
+        }
+        if self.needs_load {
+            // TODO: this uses native endianness
+            self.pyimport("ctypes", None);
+            self.src.push_str(
+                "
+                    def _load(ty: Any, mem: wasmtime.Memory, store: wasmtime.Storelike, base: int, offset: int) -> Any:
+                        ptr = (base & 0xffffffff) + offset
+                        if ptr + ctypes.sizeof(ty) > mem.data_len(store):
+                            raise IndexError('out-of-bounds store')
+                        raw_base = mem.data_ptr(store)
+                        c_ptr = ctypes.POINTER(ty)(
+                            ty.from_address(ctypes.addressof(raw_base.contents) + ptr)
+                        )
+                        return c_ptr[0]
+                ",
+            );
+        }
+        if self.needs_validate_guest_char {
+            self.src.push_str(
+                "
+                    def _validate_guest_char(i: int) -> str:
+                        if i > 0x10ffff or (i >= 0xd800 and i <= 0xdfff):
+                            raise TypeError('not a valid char');
+                        return chr(i)
+                ",
+            );
+        }
+        if self.needs_expected {
+            self.pyimport("dataclasses", "dataclass");
+            self.pyimport("typing", "TypeVar");
+            self.pyimport("typing", "Generic");
+            self.pyimport("typing", "Union");
+            self.needs_t_typevar = true;
+            self.src.push_str(
+                "
+                    @dataclass
+                    class Ok(Generic[T]):
+                        value: T
+                    E = TypeVar('E')
+                    @dataclass
+                    class Err(Generic[E]):
+                        value: E
+
+                    Expected = Union[Ok[T], Err[E]]
+                ",
+            );
+        }
+        if self.needs_i32_to_f32 || self.needs_f32_to_i32 {
+            self.pyimport("ctypes", None);
+            self.src
+                .push_str("_i32_to_f32_i32 = ctypes.pointer(ctypes.c_int32(0))\n");
+            self.src.push_str(
+                "_i32_to_f32_f32 = ctypes.cast(_i32_to_f32_i32, ctypes.POINTER(ctypes.c_float))\n",
+            );
+            if self.needs_i32_to_f32 {
+                self.src.push_str(
+                    "
+                        def _i32_to_f32(i: int) -> float:
+                            _i32_to_f32_i32[0] = i     # type: ignore
+                            return _i32_to_f32_f32[0]  # type: ignore
+                    ",
+                );
+            }
+            if self.needs_f32_to_i32 {
+                self.src.push_str(
+                    "
+                        def _f32_to_i32(i: float) -> int:
+                            _i32_to_f32_f32[0] = i    # type: ignore
+                            return _i32_to_f32_i32[0] # type: ignore
+                    ",
+                );
+            }
+        }
+        if self.needs_i64_to_f64 || self.needs_f64_to_i64 {
+            self.pyimport("ctypes", None);
+            self.src
+                .push_str("_i64_to_f64_i64 = ctypes.pointer(ctypes.c_int64(0))\n");
+            self.src.push_str(
+                "_i64_to_f64_f64 = ctypes.cast(_i64_to_f64_i64, ctypes.POINTER(ctypes.c_double))\n",
+            );
+            if self.needs_i64_to_f64 {
+                self.src.push_str(
+                    "
+                        def _i64_to_f64(i: int) -> float:
+                            _i64_to_f64_i64[0] = i    # type: ignore
+                            return _i64_to_f64_f64[0] # type: ignore
+                    ",
+                );
+            }
+            if self.needs_f64_to_i64 {
+                self.src.push_str(
+                    "
+                        def _f64_to_i64(i: float) -> int:
+                            _i64_to_f64_f64[0] = i    # type: ignore
+                            return _i64_to_f64_i64[0] # type: ignore
+                    ",
+                );
+            }
+        }
+        if self.needs_decode_utf8 {
+            self.pyimport("ctypes", None);
+            self.src.push_str(
+                "
+                    def _decode_utf8(mem: wasmtime.Memory, store: wasmtime.Storelike, ptr: int, len: int) -> str:
+                        ptr = ptr & 0xffffffff
+                        len = len & 0xffffffff
+                        if ptr + len > mem.data_len(store):
+                            raise IndexError('string out of bounds')
+                        base = mem.data_ptr(store)
+                        base = ctypes.POINTER(ctypes.c_ubyte)(
+                            ctypes.c_ubyte.from_address(ctypes.addressof(base.contents) + ptr)
+                        )
+                        return ctypes.string_at(base, len).decode('utf-8')
+                ",
+            );
+        }
+        if self.needs_encode_utf8 {
+            self.pyimport("ctypes", None);
+            self.pyimport("typing", "Tuple");
+            self.src.push_str(
+                "
+                    def _encode_utf8(val: str, realloc: wasmtime.Func, mem: wasmtime.Memory, store: wasmtime.Storelike) -> Tuple[int, int]:
+                        bytes = val.encode('utf8')
+                        ptr = realloc(store, 0, 0, 1, len(bytes))
+                        assert(isinstance(ptr, int))
+                        ptr = ptr & 0xffffffff
+                        if ptr + len(bytes) > mem.data_len(store):
+                            raise IndexError('string out of bounds')
+                        base = mem.data_ptr(store)
+                        base = ctypes.POINTER(ctypes.c_ubyte)(
+                            ctypes.c_ubyte.from_address(ctypes.addressof(base.contents) + ptr)
+                        )
+                        ctypes.memmove(base, bytes, len(bytes))
+                        return (ptr, len(bytes))
+                ",
+            );
+        }
+        if self.needs_list_canon_lift {
+            self.pyimport("ctypes", None);
+            self.pyimport("typing", "List");
+            // TODO: this is doing a native-endian read, not a little-endian
+            // read
+            self.src.push_str(
+                "
+                    def _list_canon_lift(ptr: int, len: int, size: int, ty: Any, mem: wasmtime.Memory ,store: wasmtime.Storelike) -> Any:
+                        ptr = ptr & 0xffffffff
+                        len = len & 0xffffffff
+                        if ptr + len * size > mem.data_len(store):
+                            raise IndexError('list out of bounds')
+                        raw_base = mem.data_ptr(store)
+                        base = ctypes.POINTER(ty)(
+                            ty.from_address(ctypes.addressof(raw_base.contents) + ptr)
+                        )
+                        if ty == ctypes.c_uint8:
+                            return ctypes.string_at(base, len)
+                        return base[:len]
+                ",
+            );
+        }
+        if self.needs_list_canon_lower {
+            self.pyimport("ctypes", None);
+            self.pyimport("typing", "List");
+            self.pyimport("typing", "Tuple");
+            // TODO: is there a faster way to memcpy other than iterating over
+            // the input list?
+            // TODO: this is doing a native-endian write, not a little-endian
+            // write
+            self.src.push_str(
+                "
+                    def _list_canon_lower(list: Any, ty: Any, size: int, align: int, realloc: wasmtime.Func, mem: wasmtime.Memory, store: wasmtime.Storelike) -> Tuple[int, int]:
+                        total_size = size * len(list)
+                        ptr = realloc(store, 0, 0, align, total_size)
+                        assert(isinstance(ptr, int))
+                        ptr = ptr & 0xffffffff
+                        if ptr + total_size > mem.data_len(store):
+                            raise IndexError('list realloc return of bounds')
+                        raw_base = mem.data_ptr(store)
+                        base = ctypes.POINTER(ty)(
+                            ty.from_address(ctypes.addressof(raw_base.contents) + ptr)
+                        )
+                        for i, val in enumerate(list):
+                            base[i] = val
+                        return (ptr, len(list))
+                ",
+            );
+        }
+
+        if iface.resources.len() > 0 {
+            self.pyimport("typing", "TypeVar");
+            self.pyimport("typing", "Generic");
+            self.pyimport("typing", "List");
+            self.pyimport("typing", "Optional");
+            self.pyimport("dataclasses", "dataclass");
+            self.needs_t_typevar = true;
+            self.src.push_str(
+                "
+                    @dataclass
+                    class SlabEntry(Generic[T]):
+                        next: int
+                        val: Optional[T]
+
+                    class Slab(Generic[T]):
+                        head: int
+                        list: List[SlabEntry[T]]
+
+                        def __init__(self) -> None:
+                            self.list = []
+                            self.head = 0
+
+                        def insert(self, val: T) -> int:
+                            if self.head >= len(self.list):
+                                self.list.append(SlabEntry(next = len(self.list) + 1, val = None))
+                            ret = self.head
+                            slot = self.list[ret]
+                            self.head = slot.next
+                            slot.next = -1
+                            slot.val = val
+                            return ret
+
+                        def get(self, idx: int) -> T:
+                            if idx >= len(self.list):
+                                raise IndexError('handle index not valid')
+                            slot = self.list[idx]
+                            if slot.next == -1:
+                                assert(slot.val is not None)
+                                return slot.val
+                            raise IndexError('handle index not valid')
+
+                        def remove(self, idx: int) -> T:
+                            ret = self.get(idx)
+                            slot = self.list[idx]
+                            slot.val = None
+                            slot.next = self.head
+                            self.head = idx
+                            return ret
+                ",
+            );
+            if self.needs_push_buffer {
+                self.pyimport("typing", "TypeVar");
+                self.pyimport("typing", "Generic");
+                self.pyimport("typing", "Callable");
+                self.needs_t_typevar = true;
+                self.src.push_str(
+                    "
+                        class PushBuffer(Generic[T]):
+                            def __init__(self, ptr: int, len: int, size: int, write: Callable) -> None:
+                                self.ptr = ptr
+                                self.len = len
+                                self.size = size
+                                self.write = write
+
+                            def __len__(self) -> int:
+                                return self.len
+
+                            def push(self, val: T) -> bool:
+                                if self.len == 0:
+                                    return False;
+                                self.len -= 1;
+                                self.write(val, self.ptr);
+                                self.ptr += self.size;
+                                return True
+                    ",
+                )
+            }
+            if self.needs_pull_buffer {
+                self.pyimport("typing", "TypeVar");
+                self.pyimport("typing", "Generic");
+                self.pyimport("typing", "Callable");
+                self.needs_t_typevar = true;
+                self.src.push_str(
+                    "
+                        class PullBuffer(Generic[T]):
+                            def __init__(self, ptr: int, len: int, size: int, read: Callable) -> None:
+                                self.len = len
+                                self.ptr = ptr
+                                self.size = size
+                                self.read = read
+
+                            def __len__(self) -> int:
+                                return self.len
+
+                            def pull(self) -> Optional[T]:
+                                if self.len == 0:
+                                    return None
+                                self.len -= 1
+                                ret: T = self.read(self.ptr)
+                                self.ptr += self.size
+                                return ret
+                    ",
+                )
+            }
+        }
+    }
+
+    fn type_string(&mut self, iface: &Interface, ty: &Type) -> String {
+        let prev = mem::take(&mut self.src);
+        self.print_ty(iface, ty);
+        mem::replace(&mut self.src, prev).into()
+    }
+
+    fn print_ty(&mut self, iface: &Interface, ty: &Type) {
+        match ty {
+            Type::U8
+            | Type::S8
+            | Type::U16
+            | Type::S16
+            | Type::U32
+            | Type::S32
+            | Type::U64
+            | Type::S64
+            | Type::Usize
+            | Type::CChar => self.src.push_str("int"),
+            Type::F32 | Type::F64 => self.src.push_str("float"),
+            Type::Char => self.src.push_str("str"),
+            Type::Handle(id) => {
+                // In general we want to use quotes around this to support
+                // forward-references (such as a method on a resource returning
+                // that resource), but that would otherwise generate type alias
+                // annotations that look like `Foo = 'HandleType'` which isn't
+                // creating a type alias but rather a string definition. Hack
+                // around that here to detect the type alias scenario and don't
+                // surround the type with quotes, otherwise surround with
+                // single-quotes.
+                let suffix = if self.src.ends_with(" = ") {
+                    ""
+                } else {
+                    self.src.push_str("'");
+                    "'"
+                };
+                self.src
+                    .push_str(&iface.resources[*id].name.to_camel_case());
+                self.src.push_str(suffix);
+            }
+            Type::Id(id) => {
+                let ty = &iface.types[*id];
+                if let Some(name) = &ty.name {
+                    self.src.push_str(&name.to_camel_case());
+                    return;
+                }
+                match &ty.kind {
+                    TypeDefKind::Type(t) => self.print_ty(iface, t),
+                    TypeDefKind::Record(r) if r.is_tuple() => {
+                        self.print_tuple(iface, r.fields.iter().map(|f| &f.ty))
+                    }
+                    TypeDefKind::Record(_) => unreachable!(),
+                    TypeDefKind::Variant(v) => {
+                        if v.is_bool() {
+                            self.src.push_str("bool");
+                        } else if let Some(t) = v.as_option() {
+                            self.pyimport("typing", "Optional");
+                            self.src.push_str("Optional[");
+                            self.print_ty(iface, t);
+                            self.src.push_str("]");
+                        } else if let Some((ok, err)) = v.as_expected() {
+                            self.needs_expected = true;
+                            self.src.push_str("Expected[");
+                            match ok {
+                                Some(t) => self.print_ty(iface, t),
+                                None => self.src.push_str("None"),
+                            }
+                            self.src.push_str(", ");
+                            match err {
+                                Some(t) => self.print_ty(iface, t),
+                                None => self.src.push_str("None"),
+                            }
+                            self.src.push_str("]");
+                        } else {
+                            unreachable!()
+                        }
+                    }
+                    TypeDefKind::List(t) => self.print_list(iface, t),
+                    TypeDefKind::Pointer(_) | TypeDefKind::ConstPointer(_) => {
+                        self.src.push_str("int")
+                    }
+                    TypeDefKind::PushBuffer(t) => self.print_buffer(iface, true, t),
+                    TypeDefKind::PullBuffer(t) => self.print_buffer(iface, false, t),
+                }
+            }
+        }
+    }
+
+    fn print_tuple<'a>(&mut self, iface: &Interface, types: impl IntoIterator<Item = &'a Type>) {
+        let types = types.into_iter().collect::<Vec<_>>();
+        if types.is_empty() {
+            return self.src.push_str("None");
+        }
+        self.pyimport("typing", "Tuple");
+        self.src.push_str("Tuple[");
+        for (i, t) in types.iter().enumerate() {
+            if i > 0 {
+                self.src.push_str(", ");
+            }
+            self.print_ty(iface, t);
+        }
+        self.src.push_str("]");
+    }
+
+    fn print_buffer(&mut self, iface: &Interface, push: bool, ty: &Type) {
+        if push {
+            self.needs_push_buffer = true;
+            self.src.push_str("PushBuffer");
+        } else {
+            self.needs_pull_buffer = true;
+            self.src.push_str("PullBuffer");
+        }
+        self.src.push_str("[");
+        self.print_ty(iface, ty);
+        self.src.push_str("]");
+    }
+
+    fn print_list(&mut self, iface: &Interface, element: &Type) {
+        match element {
+            Type::Char => self.src.push_str("str"),
+            Type::U8 => self.src.push_str("bytes"),
+            t => {
+                self.pyimport("typing", "List");
+                self.src.push_str("List[");
+                self.print_ty(iface, t);
+                self.src.push_str("]");
+            }
+        }
+    }
+
+    fn pyimport<'a>(&mut self, module: &str, name: impl Into<Option<&'a str>>) {
+        let name = name.into();
+        let list = self
+            .pyimports
+            .entry(module.to_string())
+            .or_insert(match name {
+                Some(_) => Some(BTreeSet::new()),
+                None => None,
+            });
+        match name {
+            Some(name) => {
+                assert!(list.is_some());
+                list.as_mut().unwrap().insert(name.to_string());
+            }
+            None => assert!(list.is_none()),
+        }
+    }
+
+    fn array_ty(&self, iface: &Interface, ty: &Type) -> Option<&'static str> {
+        match ty {
+            Type::U8 | Type::CChar => Some("c_uint8"),
+            Type::S8 => Some("c_int8"),
+            Type::U16 => Some("c_uint16"),
+            Type::S16 => Some("c_int16"),
+            Type::U32 | Type::Usize => Some("c_uint32"),
+            Type::S32 => Some("c_int32"),
+            Type::U64 => Some("c_uint64"),
+            Type::S64 => Some("c_int64"),
+            Type::F32 => Some("c_float"),
+            Type::F64 => Some("c_double"),
+            Type::Char => None,
+            Type::Handle(_) => None,
+            Type::Id(id) => match &iface.types[*id].kind {
+                TypeDefKind::Type(t) => self.array_ty(iface, t),
+                _ => None,
+            },
+        }
+    }
+
+    fn docs(&mut self, docs: &Docs) {
+        let docs = match &docs.contents {
+            Some(docs) => docs,
+            None => return,
+        };
+        for line in docs.lines() {
+            self.src.push_str(&format!("# {}\n", line));
+        }
+    }
+
+    fn print_sig(&mut self, iface: &Interface, func: &Function) -> Vec<String> {
+        if !self.in_import {
+            if let FunctionKind::Static { .. } = func.kind {
+                self.src.push_str("@classmethod\n");
+            }
+        }
+        self.src.push_str("def ");
+        match &func.kind {
+            FunctionKind::Method { .. } => self.src.push_str(&func.item_name().to_snake_case()),
+            FunctionKind::Static { .. } if !self.in_import => {
+                self.src.push_str(&func.item_name().to_snake_case())
+            }
+            _ => self.src.push_str(&func.name.to_snake_case()),
+        }
+        if self.in_import {
+            self.src.push_str("(self");
+        } else if let FunctionKind::Static { .. } = func.kind {
+            self.src.push_str("(cls, caller: wasmtime.Store, obj: '");
+            self.src.push_str(&iface.name.to_camel_case());
+            self.src.push_str("'");
+        } else {
+            self.src.push_str("(self, caller: wasmtime.Store");
+        }
+        let mut params = Vec::new();
+        for (i, (param, ty)) in func.params.iter().enumerate() {
+            if i == 0 {
+                if let FunctionKind::Method { .. } = func.kind {
+                    params.push("self".to_string());
+                    continue;
+                }
+            }
+            self.src.push_str(", ");
+            self.src.push_str(&param.to_snake_case());
+            params.push(param.to_snake_case());
+            self.src.push_str(": ");
+            self.print_ty(iface, ty);
+        }
+        self.src.push_str(") -> ");
+        match func.results.len() {
+            0 => self.src.push_str("None"),
+            1 => self.print_ty(iface, &func.results[0].1),
+            _ => self.print_tuple(iface, func.results.iter().map(|p| &p.1)),
+        }
+        params
+    }
+}
+
+impl Generator for WasmtimePy {
+    fn preprocess(&mut self, iface: &Interface, dir: Direction) {
+        self.sizes.fill(dir, iface);
+        self.in_import = dir == Direction::Import;
+    }
+
+    fn type_record(
+        &mut self,
+        iface: &Interface,
+        _id: TypeId,
+        name: &str,
+        record: &Record,
+        docs: &Docs,
+    ) {
+        self.docs(docs);
+        if record.is_tuple() {
+            self.src.push_str(&format!("{} = ", name.to_camel_case()));
+            self.print_tuple(iface, record.fields.iter().map(|f| &f.ty));
+        } else if record.is_flags() {
+            self.pyimport("enum", "Flag");
+            self.pyimport("enum", "auto");
+            self.src
+                .push_str(&format!("class {}(Flag):\n", name.to_camel_case()));
+            self.indent();
+            for field in record.fields.iter() {
+                self.docs(&field.docs);
+                self.src
+                    .push_str(&format!("{} = auto()\n", field.name.to_shouty_snake_case()));
+            }
+            if record.fields.is_empty() {
+                self.src.push_str("pass\n");
+            }
+            self.deindent();
+        } else {
+            self.pyimport("dataclasses", "dataclass");
+            self.src
+                .push_str(&format!("@dataclass\nclass {}:\n", name.to_camel_case()));
+            self.indent();
+            for field in record.fields.iter() {
+                self.docs(&field.docs);
+                self.src
+                    .push_str(&format!("{}: ", field.name.to_snake_case()));
+                self.print_ty(iface, &field.ty);
+                self.src.push_str("\n");
+            }
+            if record.fields.is_empty() {
+                self.src.push_str("pass\n");
+            }
+            self.deindent();
+        }
+        self.src.push_str("\n");
+    }
+
+    fn type_variant(
+        &mut self,
+        iface: &Interface,
+        _id: TypeId,
+        name: &str,
+        variant: &Variant,
+        docs: &Docs,
+    ) {
+        self.docs(docs);
+        if variant.is_bool() {
+            self.src
+                .push_str(&format!("{} = bool\n", name.to_camel_case()));
+        } else if variant.is_enum() {
+            self.pyimport("enum", "Enum");
+            self.src
+                .push_str(&format!("class {}(Enum):\n", name.to_camel_case()));
+            self.indent();
+            for (i, case) in variant.cases.iter().enumerate() {
+                self.docs(&case.docs);
+
+                // TODO this handling of digits should be more general and
+                // shouldn't be here just to fix the one case in wasi where an
+                // enum variant is "2big" and doesn't generate valid Python. We
+                // should probably apply this to all generated Python
+                // identifiers.
+                let mut name = case.name.to_shouty_snake_case();
+                if name.chars().next().unwrap().is_digit(10) {
+                    name = format!("_{}", name);
+                }
+                self.src.push_str(&format!("{} = {}\n", name, i));
+            }
+            self.deindent();
+        } else if let Some(t) = variant.as_option() {
+            self.pyimport("typing", "Optional");
+            self.src
+                .push_str(&format!("{} = Optional[", name.to_camel_case()));
+            self.print_ty(iface, t);
+            self.src.push_str("]\n");
+        } else if let Some((ok, err)) = variant.as_expected() {
+            self.needs_expected = true;
+            self.src
+                .push_str(&format!("{} = Expected[", name.to_camel_case()));
+            match ok {
+                Some(t) => self.print_ty(iface, t),
+                None => self.src.push_str("None"),
+            }
+            self.src.push_str(", ");
+            match err {
+                Some(t) => self.print_ty(iface, t),
+                None => self.src.push_str("None"),
+            }
+            self.src.push_str("]\n");
+        } else {
+            self.pyimport("dataclasses", "dataclass");
+            let mut cases = Vec::new();
+            for case in variant.cases.iter() {
+                self.docs(&case.docs);
+                self.src.push_str("@dataclass\n");
+                let name = format!("{}{}", name.to_camel_case(), case.name.to_camel_case());
+                self.src.push_str(&format!("class {}:\n", name));
+                self.indent();
+                match &case.ty {
+                    Some(ty) => {
+                        self.src.push_str("value: ");
+                        self.print_ty(iface, ty);
+                        self.src.push_str("\n");
+                    }
+                    None => self.src.push_str("pass\n"),
+                }
+                self.deindent();
+                self.src.push_str("\n");
+                cases.push(name);
+            }
+
+            self.pyimport("typing", "Union");
+            self.src.push_str(&format!(
+                "{} = Union[{}]\n",
+                name.to_camel_case(),
+                cases.join(", "),
+            ));
+        }
+        self.src.push_str("\n");
+    }
+
+    fn type_resource(&mut self, _iface: &Interface, _ty: ResourceId) {
+        // if !self.in_import {
+        //     self.exported_resources.insert(ty);
+        // }
+    }
+
+    fn type_alias(&mut self, iface: &Interface, _id: TypeId, name: &str, ty: &Type, docs: &Docs) {
+        self.docs(docs);
+        self.src.push_str(&format!("{} = ", name.to_camel_case()));
+        self.print_ty(iface, ty);
+        self.src.push_str("\n");
+    }
+
+    fn type_list(&mut self, iface: &Interface, _id: TypeId, name: &str, ty: &Type, docs: &Docs) {
+        self.docs(docs);
+        self.src.push_str(&format!("{} = ", name.to_camel_case()));
+        self.print_list(iface, ty);
+        self.src.push_str("\n");
+    }
+
+    fn type_pointer(
+        &mut self,
+        _iface: &Interface,
+        _id: TypeId,
+        _name: &str,
+        _const_: bool,
+        _ty: &Type,
+        _docs: &Docs,
+    ) {
+        // drop((iface, _id, name, const_, ty, docs));
+    }
+
+    fn type_builtin(&mut self, iface: &Interface, id: TypeId, name: &str, ty: &Type, docs: &Docs) {
+        self.type_alias(iface, id, name, ty, docs);
+    }
+
+    fn type_push_buffer(
+        &mut self,
+        iface: &Interface,
+        _id: TypeId,
+        name: &str,
+        ty: &Type,
+        docs: &Docs,
+    ) {
+        self.docs(docs);
+        self.src.push_str(&format!("{} = ", name.to_camel_case()));
+        self.print_buffer(iface, true, ty);
+        self.src.push_str("\n");
+    }
+
+    fn type_pull_buffer(
+        &mut self,
+        iface: &Interface,
+        _id: TypeId,
+        name: &str,
+        ty: &Type,
+        docs: &Docs,
+    ) {
+        self.docs(docs);
+        self.src.push_str(&format!("{} = ", name.to_camel_case()));
+        self.print_buffer(iface, false, ty);
+        self.src.push_str("\n");
+    }
+
+    fn import(&mut self, iface: &Interface, func: &Function) {
+        let prev = mem::take(&mut self.src);
+
+        self.print_sig(iface, func);
+        let pysig = mem::take(&mut self.src).into();
+
+        let sig = iface.wasm_signature(Direction::Import, func);
+        self.src.push_str(&format!(
+            "def {}(caller: wasmtime.Caller",
+            func.name.to_snake_case(),
+        ));
+        let mut params = Vec::new();
+        for (i, param) in sig.params.iter().enumerate() {
+            self.src.push_str(", ");
+            let name = format!("arg{}", i);
+            self.src.push_str(&name);
+            self.src.push_str(": ");
+            self.src.push_str(wasm_ty_typing(*param));
+            params.push(name);
+        }
+        self.src.push_str(") -> ");
+        match sig.results.len() {
+            0 => self.src.push_str("None"),
+            1 => self.src.push_str(wasm_ty_typing(sig.results[0])),
+            _ => unimplemented!(),
+        }
+        self.src.push_str(":\n");
+        self.indent();
+
+        let mut f = FunctionBindgen::new(self, params);
+        iface.call(
+            Direction::Import,
+            LiftLower::LiftArgsLowerResults,
+            func,
+            &mut f,
+        );
+
+        let FunctionBindgen {
+            src,
+            needs_memory,
+            needs_realloc,
+            needs_free,
+            mut locals,
+            ..
+        } = f;
+
+        if needs_memory {
+            // TODO: hardcoding "memory"
+            self.src.push_str("m = caller[\"memory\"]\n");
+            self.src
+                .push_str("assert(isinstance(m, wasmtime.Memory))\n");
+            self.pyimport("typing", "cast");
+            self.src.push_str("memory = cast(wasmtime.Memory, m)\n");
+            locals.insert("memory").unwrap();
+        }
+
+        if let Some(name) = needs_realloc {
+            self.src
+                .push_str(&format!("realloc = caller[\"{}\"]\n", name));
+            self.src
+                .push_str("assert(isinstance(realloc, wasmtime.Func))\n");
+            locals.insert("realloc").unwrap();
+        }
+
+        if let Some(name) = needs_free {
+            self.src.push_str(&format!("free = caller[\"{}\"]\n", name));
+            self.src
+                .push_str("assert(isinstance(free, wasmtime.Func))\n");
+            locals.insert("free").unwrap();
+        }
+        self.src.push_str(&src);
+        self.deindent();
+
+        let src = mem::replace(&mut self.src, prev);
+        let mut wasm_ty = String::from("wasmtime.FuncType([");
+        wasm_ty.push_str(
+            &sig.params
+                .iter()
+                .map(|t| wasm_ty_ctor(*t))
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        wasm_ty.push_str("], [");
+        wasm_ty.push_str(
+            &sig.results
+                .iter()
+                .map(|t| wasm_ty_ctor(*t))
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        wasm_ty.push_str("])");
+        let import = Import {
+            name: func.name.clone(),
+            src,
+            wasm_ty,
+            pysig,
+        };
+        let imports = self
+            .imports
+            .entry(iface.name.to_string())
+            .or_insert(Imports::default());
+        let dst = match &func.kind {
+            FunctionKind::Freestanding | FunctionKind::Static { .. } => {
+                &mut imports.freestanding_funcs
+            }
+            FunctionKind::Method { resource, .. } => imports
+                .resource_funcs
+                .entry(*resource)
+                .or_insert(Vec::new()),
+        };
+        dst.push(import);
+    }
+
+    fn export(&mut self, iface: &Interface, func: &Function) {
+        let prev = mem::take(&mut self.src);
+
+        let params = self.print_sig(iface, func);
+        self.src.push_str(":\n");
+        self.indent();
+
+        let src_object = match &func.kind {
+            FunctionKind::Freestanding => "self".to_string(),
+            FunctionKind::Static { .. } => "obj".to_string(),
+            FunctionKind::Method { .. } => "self._obj".to_string(),
+        };
+        let mut f = FunctionBindgen::new(self, params);
+        f.src_object = src_object;
+        iface.call(
+            Direction::Export,
+            LiftLower::LowerArgsLiftResults,
+            func,
+            &mut f,
+        );
+
+        let FunctionBindgen {
+            src,
+            needs_memory,
+            needs_realloc,
+            needs_free,
+            src_object,
+            ..
+        } = f;
+        if needs_memory {
+            // TODO: hardcoding "memory"
+            self.src
+                .push_str(&format!("memory = {}._memory;\n", src_object));
+        }
+
+        if let Some(name) = &needs_realloc {
+            self.src.push_str(&format!(
+                "realloc = {}._{}\n",
+                src_object,
+                name.to_snake_case(),
+            ));
+        }
+
+        if let Some(name) = &needs_free {
+            self.src.push_str(&format!(
+                "free = {}._{}\n",
+                src_object,
+                name.to_snake_case(),
+            ));
+        }
+        self.src.push_str(&src);
+        self.deindent();
+
+        let exports = self
+            .exports
+            .entry(iface.name.to_string())
+            .or_insert_with(Exports::default);
+        if needs_memory {
+            exports
+                .fields
+                .insert("memory".to_string(), "wasmtime.Memory");
+        }
+        if let Some(name) = &needs_realloc {
+            exports.fields.insert(name.clone(), "wasmtime.Func");
+        }
+        if let Some(name) = &needs_free {
+            exports.fields.insert(name.clone(), "wasmtime.Func");
+        }
+        exports.fields.insert(func.name.clone(), "wasmtime.Func");
+
+        let func_body = mem::replace(&mut self.src, prev);
+        let dst = match &func.kind {
+            FunctionKind::Freestanding => &mut exports.freestanding_funcs,
+            FunctionKind::Static { resource, .. } | FunctionKind::Method { resource, .. } => {
+                exports
+                    .resource_funcs
+                    .entry(*resource)
+                    .or_insert(Vec::new())
+            }
+        };
+        dst.push(func_body);
+    }
+
+    fn finish(&mut self, iface: &Interface, files: &mut Files) {
+        self.pyimport("typing", "Any");
+        self.pyimport("abc", "abstractmethod");
+
+        let types = mem::take(&mut self.src);
+        self.print_intrinsics(iface);
+        let intrinsics = mem::take(&mut self.src);
+
+        for (k, v) in self.pyimports.iter() {
+            match v {
+                Some(list) => {
+                    let list = list.iter().cloned().collect::<Vec<_>>().join(", ");
+                    self.src.push_str(&format!("from {} import {}\n", k, list));
+                }
+                None => {
+                    self.src.push_str(&format!("import {}\n", k));
+                }
+            }
+        }
+        self.src.push_str("import wasmtime\n");
+        self.src.push_str(
+            "
+                try:
+                    from typing import Protocol
+                except ImportError:
+                    class Protocol: # type: ignore
+                        pass
+            ",
+        );
+        self.src.push_str("\n");
+
+        if self.needs_t_typevar {
+            self.src.push_str("T = TypeVar('T')\n");
+        }
+
+        self.src.push_str(&intrinsics);
+        for (id, r) in iface.resources.iter() {
+            let name = r.name.to_camel_case();
+            if self.in_import {
+                self.src.push_str(&format!("class {}(Protocol):\n", name));
+                self.src.indent(2);
+                self.src.push_str("def drop(self) -> None:\n");
+                self.src.indent(2);
+                self.src.push_str("pass\n");
+                self.src.deindent(2);
+
+                for (_, funcs) in self.imports.iter() {
+                    if let Some(funcs) = funcs.resource_funcs.get(&id) {
+                        for func in funcs {
+                            self.src.push_str("@abstractmethod\n");
+                            self.src.push_str(&func.pysig);
+                            self.src.push_str(":\n");
+                            self.src.indent(2);
+                            self.src.push_str("raise NotImplementedError\n");
+                            self.src.deindent(2);
+                        }
+                    }
+                }
+                self.src.deindent(2);
+            } else {
+                self.src.push_str(&format!("class {}:\n", name));
+                self.src.indent(2);
+                self.src.push_str(&format!(
+                    "
+                        _wasm_val: int
+                        _refcnt: int
+                        _obj: '{iface}'
+                        _destroyed: bool
+
+                        def __init__(self, val: int, obj: '{iface}') -> None:
+                            self._wasm_val = val
+                            self._refcnt = 1
+                            self._obj = obj
+                            self._destroyed = False
+
+                        def clone(self) -> '{name}':
+                            self._refcnt += 1
+                            return self
+
+                        def drop(self, store: wasmtime.Storelike) -> None:
+                            self._refcnt -= 1;
+                            if self._refcnt != 0:
+                                return
+                            assert(not self._destroyed)
+                            self._destroyed = True
+                            self._obj._canonical_abi_drop_{drop}(store, self._wasm_val)
+
+                        def __del__(self) -> None:
+                            if not self._destroyed:
+                                raise RuntimeError('wasm object not dropped')
+                    ",
+                    name = name,
+                    iface = iface.name.to_camel_case(),
+                    drop = name.to_snake_case(),
+                ));
+
+                for (_, exports) in self.exports.iter() {
+                    if let Some(funcs) = exports.resource_funcs.get(&id) {
+                        for func in funcs {
+                            self.src.push_str(func);
+                        }
+                    }
+                }
+
+                self.src.deindent(2);
+            }
+        }
+        self.src.push_str(&types);
+
+        for (module, funcs) in mem::take(&mut self.imports) {
+            self.src
+                .push_str(&format!("class {}(Protocol):\n", module.to_camel_case()));
+            self.indent();
+            for func in funcs.freestanding_funcs.iter() {
+                self.src.push_str("@abstractmethod\n");
+                self.src.push_str(&func.pysig);
+                self.src.push_str(":\n");
+                self.indent();
+                self.src.push_str("raise NotImplementedError\n");
+                self.deindent();
+            }
+            self.deindent();
+            self.src.push_str("\n");
+
+            self.src.push_str(&format!(
+                "def add_{}_to_linker(linker: wasmtime.Linker, store: wasmtime.Store, host: {}) -> None:\n",
+                module.to_snake_case(),
+                module.to_camel_case(),
+            ));
+            self.indent();
+
+            for (id, r) in iface.resources.iter() {
+                self.src.push_str(&format!(
+                    "_resources{}: Slab[{}] = Slab()\n",
+                    id.index(),
+                    r.name.to_camel_case()
+                ));
+            }
+
+            for func in funcs
+                .freestanding_funcs
+                .iter()
+                .chain(funcs.resource_funcs.values().flat_map(|v| v))
+            {
+                self.src.push_str(&format!("ty = {}\n", func.wasm_ty));
+                self.src.push_str(&func.src);
+                self.src.push_str(&format!(
+                    "linker.define('{}', '{}', wasmtime.Func(store, ty, {}, access_caller = True))\n",
+                    iface.name,
+                    func.name,
+                    func.name.to_snake_case(),
+                ));
+            }
+
+            for (id, resource) in iface.resources.iter() {
+                let snake = resource.name.to_snake_case();
+
+                self.src.push_str(&format!(
+                    "def resource_drop_{}(i: int) -> None:\n  _resources{}.remove(i).drop()\n",
+                    snake,
+                    id.index(),
+                ));
+                self.src
+                    .push_str("ty = wasmtime.FuncType([wasmtime.ValType.i32()], [])\n");
+                self.src.push_str(&format!(
+                    "linker.define(\
+                        'canonical_abi', \
+                        'resource_drop_{}', \
+                        wasmtime.Func(store, ty, resource_drop_{})\
+                    )\n",
+                    resource.name, snake,
+                ));
+            }
+            self.deindent();
+        }
+
+        // This is exculsively here to get mypy to not complain about empty
+        // modules, this probably won't really get triggered much in practice
+        if !self.in_import && self.exports.is_empty() {
+            self.src
+                .push_str(&format!("class {}:\n", iface.name.to_camel_case()));
+            self.indent();
+            if iface.resources.len() == 0 {
+                self.src.push_str("pass\n");
+            } else {
+                for (_, r) in iface.resources.iter() {
+                    self.src.push_str(&format!(
+                        "_canonical_abi_drop_{}: wasmtime.Func\n",
+                        r.name.to_snake_case(),
+                    ));
+                }
+            }
+            self.deindent();
+        }
+
+        for (module, exports) in mem::take(&mut self.exports) {
+            let module = module.to_camel_case();
+            self.src.push_str(&format!("class {}:\n", module));
+            self.indent();
+
+            self.src.push_str("instance: wasmtime.Instance\n");
+            for (name, ty) in exports.fields.iter() {
+                self.src
+                    .push_str(&format!("_{}: {}\n", name.to_snake_case(), ty));
+            }
+            for (id, r) in iface.resources.iter() {
+                self.src.push_str(&format!(
+                    "_resource{}_slab: Slab[{}]\n",
+                    id.index(),
+                    r.name.to_camel_case(),
+                ));
+                self.src.push_str(&format!(
+                    "_canonical_abi_drop_{}: wasmtime.Func\n",
+                    r.name.to_snake_case(),
+                ));
+            }
+
+            self.src.push_str("def __init__(self, store: wasmtime.Store, linker: wasmtime.Linker, module: wasmtime.Module):\n");
+            self.indent();
+            for (id, r) in iface.resources.iter() {
+                self.src.push_str(&format!(
+                    "
+                       ty1 = wasmtime.FuncType([wasmtime.ValType.i32()], [])
+                       ty2 = wasmtime.FuncType([wasmtime.ValType.i32()], [wasmtime.ValType.i32()])
+                       def drop_{snake}(caller: wasmtime.Caller, idx: int) -> None:
+                            self._resource{idx}_slab.remove(idx).drop(caller);
+                       linker.define('canonical_abi', 'resource_drop_{name}', wasmtime.Func(store, ty1, drop_{snake}, access_caller = True))
+
+                       def clone_{snake}(idx: int) -> int:
+                            obj = self._resource{idx}_slab.get(idx)
+                            return self._resource{idx}_slab.insert(obj.clone())
+                       linker.define('canonical_abi', 'resource_clone_{name}', wasmtime.Func(store, ty2, clone_{snake}))
+
+                       def get_{snake}(idx: int) -> int:
+                            obj = self._resource{idx}_slab.get(idx)
+                            return obj._wasm_val
+                       linker.define('canonical_abi', 'resource_get_{name}', wasmtime.Func(store, ty2, get_{snake}))
+
+                       def new_{snake}(val: int) -> int:
+                            return self._resource{idx}_slab.insert({camel}(val, self))
+                       linker.define('canonical_abi', 'resource_new_{name}', wasmtime.Func(store, ty2, new_{snake}))
+                   ",
+                    name = r.name,
+                    camel = r.name.to_camel_case(),
+                    snake = r.name.to_snake_case(),
+                    idx = id.index(),
+                ));
+            }
+            self.src
+                .push_str("self.instance = linker.instantiate(store, module)\n");
+            self.src
+                .push_str("exports = self.instance.exports(store)\n");
+            for (name, ty) in exports.fields.iter() {
+                self.src.push_str(&format!(
+                    "
+                        {snake} = exports['{name}']
+                        assert(isinstance({snake}, {ty}))
+                        self._{snake} = {snake}
+                    ",
+                    name = name,
+                    snake = name.to_snake_case(),
+                    ty = ty,
+                ));
+            }
+            for (id, r) in iface.resources.iter() {
+                self.src.push_str(&format!(
+                    "
+                        self._resource{idx}_slab = Slab()
+                        canon_drop_{snake} = exports['canonical_abi_drop_{name}']
+                        assert(isinstance(canon_drop_{snake}, wasmtime.Func))
+                        self._canonical_abi_drop_{snake} = canon_drop_{snake}
+                    ",
+                    idx = id.index(),
+                    name = r.name,
+                    snake = r.name.to_snake_case(),
+                ));
+            }
+            self.deindent();
+
+            for func in exports.freestanding_funcs.iter() {
+                self.src.push_str(&func);
+            }
+
+            self.deindent();
+        }
+
+        files.push("bindings.py", self.src.as_bytes());
+    }
+}
+
+struct FunctionBindgen<'a> {
+    gen: &'a mut WasmtimePy,
+    locals: Ns,
+    src: Source,
+    block_storage: Vec<Source>,
+    blocks: Vec<(String, Vec<String>)>,
+    needs_memory: bool,
+    needs_realloc: Option<String>,
+    needs_free: Option<String>,
+    params: Vec<String>,
+    payloads: Vec<String>,
+    src_object: String,
+}
+
+impl FunctionBindgen<'_> {
+    fn new(gen: &mut WasmtimePy, params: Vec<String>) -> FunctionBindgen<'_> {
+        let mut locals = Ns::default();
+        locals.insert("len").unwrap(); // python built-in
+        locals.insert("base").unwrap(); // may be used as loop var
+        locals.insert("i").unwrap(); // may be used as loop var
+        for param in params.iter() {
+            locals.insert(param).unwrap();
+        }
+        FunctionBindgen {
+            gen,
+            locals,
+            src: Source::default(),
+            block_storage: Vec::new(),
+            blocks: Vec::new(),
+            needs_memory: false,
+            needs_realloc: None,
+            needs_free: None,
+            params,
+            payloads: Vec::new(),
+            src_object: "self".to_string(),
+        }
+    }
+
+    fn clamp<T>(&mut self, results: &mut Vec<String>, operands: &[String], min: T, max: T)
+    where
+        T: std::fmt::Display,
+    {
+        self.gen.needs_clamp = true;
+        results.push(format!("_clamp({}, {}, {})", operands[0], min, max));
+    }
+
+    fn load(&mut self, ty: &str, offset: i32, operands: &[String], results: &mut Vec<String>) {
+        self.needs_memory = true;
+        self.gen.needs_load = true;
+        let tmp = self.locals.tmp("load");
+        self.src.push_str(&format!(
+            "{} = _load(ctypes.{}, memory, caller, {}, {})\n",
+            tmp, ty, operands[0], offset,
+        ));
+        results.push(tmp);
+    }
+
+    fn store(&mut self, ty: &str, offset: i32, operands: &[String]) {
+        self.needs_memory = true;
+        self.gen.needs_store = true;
+        self.src.push_str(&format!(
+            "_store(ctypes.{}, memory, caller, {}, {}, {})\n",
+            ty, operands[1], offset, operands[0]
+        ));
+    }
+}
+
+impl Bindgen for FunctionBindgen<'_> {
+    type Operand = String;
+
+    fn sizes(&self) -> &SizeAlign {
+        &self.gen.sizes
+    }
+
+    fn push_block(&mut self) {
+        let prev = mem::take(&mut self.src);
+        self.block_storage.push(prev);
+    }
+
+    fn finish_block(&mut self, operands: &mut Vec<String>) {
+        let to_restore = self.block_storage.pop().unwrap();
+        let src = mem::replace(&mut self.src, to_restore);
+        self.blocks.push((src.into(), mem::take(operands)));
+    }
+
+    fn allocate_typed_space(&mut self, _iface: &Interface, _ty: TypeId) -> String {
+        unimplemented!()
+    }
+
+    fn i64_return_pointer_area(&mut self, _amt: usize) -> String {
+        unimplemented!()
+    }
+
+    fn is_list_canonical(&self, iface: &Interface, ty: &Type) -> bool {
+        self.gen.array_ty(iface, ty).is_some()
+    }
+
+    fn emit(
+        &mut self,
+        iface: &Interface,
+        inst: &Instruction<'_>,
+        operands: &mut Vec<String>,
+        results: &mut Vec<String>,
+    ) {
+        match inst {
+            Instruction::GetArg { nth } => results.push(self.params[*nth].clone()),
+            Instruction::I32Const { val } => results.push(val.to_string()),
+            Instruction::ConstZero { tys } => {
+                for t in tys.iter() {
+                    match t {
+                        WasmType::I32 | WasmType::I64 => results.push("0".to_string()),
+                        WasmType::F32 | WasmType::F64 => results.push("0.0".to_string()),
+                    }
+                }
+            }
+
+            // The representation of i32 in Python is a number, so 8/16-bit
+            // values get further clamped to ensure that the upper bits aren't
+            // set when we pass the value, ensuring that only the right number
+            // of bits are transferred.
+            Instruction::U8FromI32 => self.clamp(results, operands, u8::MIN, u8::MAX),
+            Instruction::S8FromI32 => self.clamp(results, operands, i8::MIN, i8::MAX),
+            Instruction::U16FromI32 => self.clamp(results, operands, u16::MIN, u16::MAX),
+            Instruction::S16FromI32 => self.clamp(results, operands, i16::MIN, i16::MAX),
+            // Ensure the bits of the number are treated as unsigned.
+            Instruction::U32FromI32 | Instruction::UsizeFromI32 => {
+                results.push(format!("{} & 0xffffffff", operands[0]));
+            }
+            // All bigints coming from wasm are treated as signed, so convert
+            // it to ensure it's treated as unsigned.
+            Instruction::U64FromI64 => {
+                results.push(format!("{} & 0xffffffffffffffff", operands[0]));
+            }
+            // Nothing to do signed->signed where the representations are the
+            // same.
+            Instruction::S32FromI32 | Instruction::S64FromI64 => {
+                results.push(operands.pop().unwrap())
+            }
+
+            // All values coming from the host and going to wasm need to have
+            // their ranges validated, since the host could give us any value.
+            Instruction::I32FromU8 => self.clamp(results, operands, u8::MIN, u8::MAX),
+            Instruction::I32FromS8 => self.clamp(results, operands, i8::MIN, i8::MAX),
+            Instruction::I32FromU16 => self.clamp(results, operands, u16::MIN, u16::MAX),
+            Instruction::I32FromS16 => self.clamp(results, operands, i16::MIN, i16::MAX),
+            // TODO: need to do something to get this to be represented as signed?
+            Instruction::I32FromU32 | Instruction::I32FromUsize => {
+                self.clamp(results, operands, u32::MIN, u32::MAX);
+            }
+            Instruction::I32FromS32 => self.clamp(results, operands, i32::MIN, i32::MAX),
+            // TODO: need to do something to get this to be represented as signed?
+            Instruction::I64FromU64 => self.clamp(results, operands, u64::MIN, u64::MAX),
+            Instruction::I64FromS64 => self.clamp(results, operands, i64::MIN, i64::MAX),
+
+            // Python uses `float` for f32/f64, so everything is equivalent
+            // here.
+            Instruction::If32FromF32
+            | Instruction::If64FromF64
+            | Instruction::F32FromIf32
+            | Instruction::F64FromIf64 => results.push(operands.pop().unwrap()),
+
+            // Validate that i32 values coming from wasm are indeed valid code
+            // points.
+            Instruction::CharFromI32 => {
+                self.gen.needs_validate_guest_char = true;
+                results.push(format!("_validate_guest_char({})", operands[0]));
+            }
+
+            Instruction::I32FromChar => {
+                results.push(format!("ord({})", operands[0]));
+            }
+
+            Instruction::Bitcasts { casts } => {
+                for (cast, op) in casts.iter().zip(operands) {
+                    match cast {
+                        Bitcast::I32ToF32 => {
+                            self.gen.needs_i32_to_f32 = true;
+                            results.push(format!("_i32_to_f32({})", op));
+                        }
+                        Bitcast::F32ToI32 => {
+                            self.gen.needs_f32_to_i32 = true;
+                            results.push(format!("_f32_to_i32({})", op));
+                        }
+                        Bitcast::F32ToF64 | Bitcast::F64ToF32 => results.push(op.clone()),
+                        Bitcast::I64ToF64 => {
+                            self.gen.needs_i64_to_f64 = true;
+                            results.push(format!("_i64_to_f64({})", op));
+                        }
+                        Bitcast::F64ToI64 => {
+                            self.gen.needs_f64_to_i64 = true;
+                            results.push(format!("_f64_to_i64({})", op));
+                        }
+                        Bitcast::I64ToF32 => {
+                            self.gen.needs_i32_to_f32 = true;
+                            results.push(format!("_i32_to_f32(({}) & 0xffffffff)", op));
+                        }
+                        Bitcast::F32ToI64 => {
+                            self.gen.needs_f32_to_i32 = true;
+                            results.push(format!("_f32_to_i32({})", op));
+                        }
+                        Bitcast::I32ToI64 | Bitcast::I64ToI32 | Bitcast::None => {
+                            results.push(op.clone())
+                        }
+                    }
+                }
+            }
+
+            // These instructions are used with handles when we're implementing
+            // imports. This means we interact with the `resources` slabs to
+            // translate the wasm-provided index into a Python value.
+            Instruction::I32FromOwnedHandle { ty } => {
+                results.push(format!("_resources{}.insert({})", ty.index(), operands[0]));
+            }
+            Instruction::HandleBorrowedFromI32 { ty } => {
+                results.push(format!("_resources{}.get({})", ty.index(), operands[0]));
+            }
+
+            // These instructions are used for handles to objects owned in wasm.
+            // This means that they're interacting with a wrapper class defined
+            // in Python.
+            Instruction::I32FromBorrowedHandle { ty } => {
+                let obj = self.locals.tmp("obj");
+                self.src.push_str(&format!("{} = {}\n", obj, operands[0]));
+
+                results.push(format!(
+                    "{}._resource{}_slab.insert({}.clone())",
+                    self.src_object,
+                    ty.index(),
+                    obj,
+                ));
+            }
+            Instruction::HandleOwnedFromI32 { ty } => {
+                results.push(format!(
+                    "{}._resource{}_slab.remove({})",
+                    self.src_object,
+                    ty.index(),
+                    operands[0],
+                ));
+            }
+            Instruction::RecordLower { record, .. } => {
+                if record.fields.is_empty() {
+                    return;
+                }
+                if record.is_tuple() {
+                    self.src.push_str("(");
+                    for _ in 0..record.fields.len() {
+                        let name = self.locals.tmp("tuplei");
+                        self.src.push_str(&name);
+                        self.src.push_str(",");
+                        results.push(name);
+                    }
+                    self.src.push_str(") = ");
+                    self.src.push_str(&operands[0]);
+                    self.src.push_str("\n");
+                } else {
+                    let tmp = self.locals.tmp("record");
+                    self.src.push_str(&format!("{} = {}\n", tmp, operands[0]));
+                    for field in record.fields.iter() {
+                        let name = self.locals.tmp("field");
+                        self.src.push_str(&format!(
+                            "{} = {}.{}\n",
+                            name,
+                            tmp,
+                            field.name.to_snake_case(),
+                        ));
+                        results.push(name);
+                    }
+                }
+            }
+
+            Instruction::RecordLift { record, name, .. } => {
+                if record.is_tuple() {
+                    if operands.is_empty() {
+                        results.push("None".to_string());
+                    } else {
+                        results.push(format!("({},)", operands.join(", ")));
+                    }
+                } else {
+                    let name = name.unwrap();
+                    results.push(format!("{}({})", name.to_camel_case(), operands.join(", ")));
+                }
+            }
+            Instruction::FlagsLift { name, .. } | Instruction::FlagsLift64 { name, .. } => {
+                results.push(format!("{}({})", name.to_camel_case(), operands[0]));
+            }
+            Instruction::FlagsLower { .. } | Instruction::FlagsLower64 { .. } => {
+                results.push(format!("({}).value", operands[0]));
+            }
+
+            Instruction::VariantPayloadName => {
+                let name = self.locals.tmp("payload");
+                results.push(name.clone());
+                self.payloads.push(name);
+            }
+            Instruction::BufferPayloadName => results.push("e".to_string()),
+            Instruction::VariantLower {
+                variant,
+                results: result_types,
+                name,
+                ..
+            } => {
+                let blocks = self
+                    .blocks
+                    .drain(self.blocks.len() - variant.cases.len()..)
+                    .collect::<Vec<_>>();
+                let payloads = self
+                    .payloads
+                    .drain(self.payloads.len() - variant.cases.len()..)
+                    .collect::<Vec<_>>();
+
+                if result_types.len() == 1 && variant.is_enum() {
+                    if variant.is_bool() {
+                        return results.push(format!("int({})", operands[0]));
+                    }
+                    if name.is_some() {
+                        return results.push(format!("({}).value", operands[0]));
+                    }
+                }
+
+                for _ in 0..result_types.len() {
+                    results.push(self.locals.tmp("variant"));
+                }
+
+                let mut needs_else = true;
+                for (i, ((case, (block, block_results)), payload)) in
+                    variant.cases.iter().zip(blocks).zip(payloads).enumerate()
+                {
+                    if i == 0 {
+                        self.src.push_str("if ");
+                    } else if i == 1 && variant.as_option().is_some() {
+                        needs_else = false;
+                        self.src.push_str("else:\n");
+                    } else {
+                        self.src.push_str("elif ");
+                    }
+
+                    if variant.is_bool() {
+                        self.src
+                            .push_str(&format!("{} == bool({}):\n", operands[0], i));
+                    } else if variant.as_option().is_some() {
+                        if i == 0 {
+                            self.src.push_str(&format!("{} is None:\n", operands[0]));
+                        }
+                    } else if variant.is_enum() && variant.as_expected().is_none() {
+                        self.src
+                            .push_str(&format!("{}.value == {}:\n", operands[0], i));
+                    } else {
+                        self.src.push_str(&format!(
+                            "isinstance({}, {}{}):\n",
+                            operands[0],
+                            if variant.as_expected().is_some() {
+                                String::new()
+                            } else {
+                                name.unwrap().to_camel_case()
+                            },
+                            case.name.to_camel_case()
+                        ));
+                    }
+                    self.src.indent(2);
+
+                    if case.ty.is_some() {
+                        if variant.as_option().is_some() {
+                            self.src
+                                .push_str(&format!("{} = {}\n", payload, operands[0]));
+                        } else {
+                            self.src
+                                .push_str(&format!("{} = {}.value\n", payload, operands[0]));
+                        }
+                    }
+
+                    self.src.push_str(&block);
+
+                    for (i, result) in block_results.iter().enumerate() {
+                        self.src.push_str(&format!("{} = {}\n", results[i], result));
+                    }
+                    self.src.deindent(2);
+                }
+                if needs_else {
+                    let variant_name = name.map(|s| s.to_camel_case());
+                    let variant_name = variant_name.as_deref().unwrap_or_else(|| {
+                        if variant.is_bool() {
+                            "bool"
+                        } else if variant.as_expected().is_some() {
+                            "expected"
+                        } else if variant.as_option().is_some() {
+                            "option"
+                        } else {
+                            unimplemented!()
+                        }
+                    });
+                    self.src.push_str("else:\n");
+                    self.src.indent(2);
+                    self.src.push_str(&format!(
+                        "raise TypeError(\"invalid variant specified for {}\")\n",
+                        variant_name
+                    ));
+                    self.src.deindent(2);
+                }
+            }
+
+            Instruction::VariantLift {
+                variant, name, ty, ..
+            } => {
+                let blocks = self
+                    .blocks
+                    .drain(self.blocks.len() - variant.cases.len()..)
+                    .collect::<Vec<_>>();
+
+                if let Some(name) = name {
+                    if variant.is_enum() {
+                        results.push(format!("{}({})", name.to_camel_case(), operands[0]));
+                        return;
+                    }
+                }
+
+                let result = self.locals.tmp("variant");
+                self.src.push_str(&format!(
+                    "{}: {}\n",
+                    result,
+                    self.gen.type_string(iface, &Type::Id(*ty)),
+                ));
+                for (i, (case, (block, block_results))) in
+                    variant.cases.iter().zip(blocks).enumerate()
+                {
+                    if i == 0 {
+                        self.src.push_str("if ");
+                    } else {
+                        self.src.push_str("elif ");
+                    }
+                    self.src.push_str(&format!("{} == {}:\n", operands[0], i));
+                    self.src.indent(2);
+                    self.src.push_str(&block);
+
+                    if variant.is_bool() {
+                        assert!(block_results.is_empty());
+                        self.src
+                            .push_str(&format!("{} = {}\n", result, case.name.to_camel_case(),));
+                    } else if variant.as_option().is_some() {
+                        if case.ty.is_none() {
+                            assert!(block_results.is_empty());
+                            self.src.push_str(&format!("{} = None\n", result));
+                        } else {
+                            assert!(block_results.len() == 1);
+                            self.src
+                                .push_str(&format!("{} = {}\n", result, block_results[0]));
+                        }
+                    } else {
+                        self.src.push_str(&format!(
+                            "{} = {}{}(",
+                            result,
+                            if variant.as_expected().is_some() {
+                                String::new()
+                            } else {
+                                name.unwrap().to_camel_case()
+                            },
+                            case.name.to_camel_case()
+                        ));
+                        if case.ty.is_some() {
+                            assert!(block_results.len() == 1);
+                            self.src.push_str(&block_results[0]);
+                        } else {
+                            assert!(block_results.is_empty());
+                            if variant.as_expected().is_some() {
+                                self.src.push_str("None");
+                            }
+                        }
+                        self.src.push_str(")\n");
+                    }
+                    self.src.deindent(2);
+                }
+                self.src.push_str("else:\n");
+                self.src.indent(2);
+                let variant_name = name.map(|s| s.to_camel_case());
+                let variant_name = variant_name.as_deref().unwrap_or_else(|| {
+                    if variant.is_bool() {
+                        "bool"
+                    } else if variant.as_expected().is_some() {
+                        "expected"
+                    } else if variant.as_option().is_some() {
+                        "option"
+                    } else {
+                        unimplemented!()
+                    }
+                });
+                self.src.push_str(&format!(
+                    "raise TypeError(\"invalid variant discriminant for {}\")\n",
+                    variant_name
+                ));
+                self.src.deindent(2);
+                results.push(result);
+            }
+
+            Instruction::ListCanonLower { element, realloc } => {
+                // Lowering only happens when we're passing lists into wasm,
+                // which forces us to always allocate, so this should always be
+                // `Some`.
+                let realloc = realloc.unwrap();
+                self.needs_memory = true;
+                self.needs_realloc = Some(realloc.to_string());
+
+                let ptr = self.locals.tmp("ptr");
+                let len = self.locals.tmp("len");
+                match element {
+                    Type::Char => {
+                        self.gen.needs_encode_utf8 = true;
+                        self.src.push_str(&format!(
+                            "{}, {} = _encode_utf8({}, realloc, memory, caller)\n",
+                            ptr, len, operands[0],
+                        ));
+                    }
+                    _ => {
+                        let array_ty = self.gen.array_ty(iface, element).unwrap();
+                        self.gen.needs_list_canon_lower = true;
+                        let size = self.gen.sizes.size(element);
+                        let align = self.gen.sizes.align(element);
+                        self.src.push_str(&format!(
+                            "{}, {} = _list_canon_lower({}, ctypes.{}, {}, {}, realloc, memory, caller)\n",
+                            ptr, len, operands[0], array_ty, size, align,
+                        ));
+                    }
+                };
+                results.push(ptr);
+                results.push(len);
+            }
+            Instruction::ListCanonLift { element, free, .. } => {
+                self.needs_memory = true;
+                let ptr = self.locals.tmp("ptr");
+                let len = self.locals.tmp("len");
+                self.src.push_str(&format!("{} = {}\n", ptr, operands[0]));
+                self.src.push_str(&format!("{} = {}\n", len, operands[1]));
+                let (result, align) = match element {
+                    Type::Char => {
+                        self.gen.needs_decode_utf8 = true;
+                        (format!("_decode_utf8(memory, caller, {}, {})", ptr, len), 1)
+                    }
+                    _ => {
+                        let array_ty = self.gen.array_ty(iface, element).unwrap();
+                        self.gen.needs_list_canon_lift = true;
+                        let lift = format!(
+                            "_list_canon_lift({}, {}, {}, ctypes.{}, memory, caller)",
+                            ptr,
+                            len,
+                            self.gen.sizes.size(element),
+                            array_ty,
+                        );
+                        let pyty = match element {
+                            Type::U8 => "bytes".to_string(),
+                            _ => {
+                                self.gen.pyimport("typing", "List");
+                                format!("List[{}]", self.gen.type_string(iface, element))
+                            }
+                        };
+                        self.gen.pyimport("typing", "cast");
+                        (
+                            format!("cast({}, {})", pyty, lift),
+                            self.gen.sizes.align(element),
+                        )
+                    }
+                };
+                match free {
+                    Some(free) => {
+                        self.needs_free = Some(free.to_string());
+                        let list = self.locals.tmp("list");
+                        self.src.push_str(&format!("{} = {}\n", list, result));
+                        self.src
+                            .push_str(&format!("free(caller, {}, {}, {})\n", ptr, len, align));
+                        results.push(list);
+                    }
+                    None => results.push(result),
+                }
+            }
+
+            Instruction::ListLower { element, realloc } => {
+                let base = self.payloads.pop().unwrap();
+                let e = self.payloads.pop().unwrap();
+                let realloc = realloc.unwrap();
+                let (body, body_results) = self.blocks.pop().unwrap();
+                assert!(body_results.is_empty());
+                let vec = self.locals.tmp("vec");
+                let result = self.locals.tmp("result");
+                let len = self.locals.tmp("len");
+                self.needs_realloc = Some(realloc.to_string());
+                let size = self.gen.sizes.size(element);
+                let align = self.gen.sizes.align(element);
+
+                // first store our vec-to-lower in a temporary since we'll
+                // reference it multiple times.
+                self.src.push_str(&format!("{} = {}\n", vec, operands[0]));
+                self.src.push_str(&format!("{} = len({})\n", len, vec));
+
+                // ... then realloc space for the result in the guest module
+                self.src.push_str(&format!(
+                    "{} = realloc(caller, 0, 0, {}, {} * {})\n",
+                    result, align, len, size,
+                ));
+                self.src
+                    .push_str(&format!("assert(isinstance({}, int))\n", result));
+
+                // ... then consume the vector and use the block to lower the
+                // result.
+                let i = self.locals.tmp("i");
+                self.src
+                    .push_str(&format!("for {} in range(0, {}):\n", i, len));
+                self.src.indent(2);
+                self.src.push_str(&format!("{} = {}[{}]\n", e, vec, i));
+                self.src
+                    .push_str(&format!("{} = {} + {} * {}\n", base, result, i, size));
+                self.src.push_str(&body);
+                self.src.deindent(2);
+
+                results.push(result);
+                results.push(len);
+            }
+
+            Instruction::ListLift { element, free, .. } => {
+                let (body, body_results) = self.blocks.pop().unwrap();
+                let base = self.payloads.pop().unwrap();
+                let size = self.gen.sizes.size(element);
+                let align = self.gen.sizes.align(element);
+                let ptr = self.locals.tmp("ptr");
+                let len = self.locals.tmp("len");
+                self.src.push_str(&format!("{} = {}\n", ptr, operands[0]));
+                self.src.push_str(&format!("{} = {}\n", len, operands[1]));
+                let result = self.locals.tmp("result");
+                let ty = self.gen.type_string(iface, element);
+                self.src
+                    .push_str(&format!("{}: List[{}] = []\n", result, ty));
+
+                let i = self.locals.tmp("i");
+                self.src
+                    .push_str(&format!("for {} in range(0, {}):\n", i, len));
+                self.src.indent(2);
+                self.src
+                    .push_str(&format!("{} = {} + {} * {}\n", base, ptr, i, size));
+                self.src.push_str(&body);
+                assert_eq!(body_results.len(), 1);
+                self.src
+                    .push_str(&format!("{}.append({})\n", result, body_results[0]));
+                self.src.deindent(2);
+
+                if let Some(free) = free {
+                    self.needs_free = Some(free.to_string());
+                    self.src.push_str(&format!(
+                        "free(caller, {}, {} * {}, {})\n",
+                        ptr, len, size, align,
+                    ));
+                }
+                results.push(result);
+            }
+
+            Instruction::IterElem => {
+                let name = self.locals.tmp("e");
+                results.push(name.clone());
+                self.payloads.push(name);
+            }
+            Instruction::IterBasePointer => {
+                let name = self.locals.tmp("base");
+                results.push(name.clone());
+                self.payloads.push(name);
+            }
+
+            Instruction::BufferLiftPtrLen { push, ty } => {
+                let (block, block_results) = self.blocks.pop().unwrap();
+                let base = self.payloads.pop().unwrap();
+                self.needs_memory = true;
+                let ptr = self.locals.tmp("ptr");
+                let len = self.locals.tmp("len");
+                self.src.push_str(&format!("{} = {}\n", ptr, operands[1]));
+                self.src.push_str(&format!("{} = {}\n", len, operands[2]));
+                let size = self.gen.sizes.size(ty);
+                if *push {
+                    self.gen.needs_push_buffer = true;
+                    assert!(block_results.is_empty());
+                    let write = self.locals.tmp("write_val");
+                    self.src
+                        .push_str(&format!("def {}(e, {}): # type: ignore\n", write, base));
+                    self.src.indent(2);
+                    self.src.push_str(&block);
+                    self.src.deindent(2);
+                    results.push(format!("PushBuffer({}, {}, {}, {})", ptr, len, size, write));
+                } else {
+                    self.gen.needs_pull_buffer = true;
+                    assert_eq!(block_results.len(), 1);
+                    let read = self.locals.tmp("read_val");
+                    self.src
+                        .push_str(&format!("def {}({}): # type: ignore\n", read, base));
+                    self.src.indent(2);
+                    self.src.push_str(&block);
+                    self.src.push_str(&format!("return {}\n", block_results[0]));
+                    self.src.deindent(2);
+                    results.push(format!("PullBuffer({}, {}, {}, {})", ptr, len, size, read));
+                }
+            }
+
+            //    Instruction::BufferLowerHandle { push, ty } => {
+            //        let block = self.blocks.pop().unwrap();
+            //        let size = self.sizes.size(ty);
+            //        let tmp = self.tmp();
+            //        let handle = format!("handle{}", tmp);
+            //        let closure = format!("closure{}", tmp);
+            //        self.needs_buffer_transaction = true;
+            //        if iface.all_bits_valid(ty) {
+            //            let method = if *push { "push_out_raw" } else { "push_in_raw" };
+            //            self.push_str(&format!(
+            //                "let {} = unsafe {{ buffer_transaction.{}({}) }};\n",
+            //                handle, method, operands[0],
+            //            ));
+            //        } else if *push {
+            //            self.closures.push_str(&format!(
+            //                "let {} = |memory: &wasmtime::Memory, base: i32| {{
+            //                    Ok(({}, {}))
+            //                }};\n",
+            //                closure, block, size,
+            //            ));
+            //            self.push_str(&format!(
+            //                "let {} = unsafe {{ buffer_transaction.push_out({}, &{}) }};\n",
+            //                handle, operands[0], closure,
+            //            ));
+            //        } else {
+            //            let start = self.src.len();
+            //            self.print_ty(iface, ty, TypeMode::AllBorrowed("'_"));
+            //            let ty = self.src[start..].to_string();
+            //            self.src.truncate(start);
+            //            self.closures.push_str(&format!(
+            //                "let {} = |memory: &wasmtime::Memory, base: i32, e: {}| {{
+            //                    {};
+            //                    Ok({})
+            //                }};\n",
+            //                closure, ty, block, size,
+            //            ));
+            //            self.push_str(&format!(
+            //                "let {} = unsafe {{ buffer_transaction.push_in({}, &{}) }};\n",
+            //                handle, operands[0], closure,
+            //            ));
+            //        }
+            //        results.push(format!("{}", handle));
+            //    }
+            Instruction::CallWasm {
+                module: _,
+                name,
+                sig,
+            } => {
+                if sig.results.len() > 0 {
+                    for i in 0..sig.results.len() {
+                        if i > 0 {
+                            self.src.push_str(", ");
+                        }
+                        let ret = self.locals.tmp("ret");
+                        self.src.push_str(&ret);
+                        results.push(ret);
+                    }
+                    self.src.push_str(" = ");
+                }
+                self.src.push_str(&self.src_object);
+                self.src.push_str("._");
+                self.src.push_str(&name.to_snake_case());
+                self.src.push_str("(caller");
+                if operands.len() > 0 {
+                    self.src.push_str(", ");
+                }
+                self.src.push_str(&operands.join(", "));
+                self.src.push_str(")\n");
+                for (ty, name) in sig.results.iter().zip(results.iter()) {
+                    let ty = match ty {
+                        WasmType::I32 | WasmType::I64 => "int",
+                        WasmType::F32 | WasmType::F64 => "float",
+                    };
+                    self.src
+                        .push_str(&format!("assert(isinstance({}, {}))\n", name, ty));
+                }
+            }
+            Instruction::CallInterface { module: _, func } => {
+                for i in 0..func.results.len() {
+                    if i > 0 {
+                        self.src.push_str(", ");
+                    }
+                    let result = self.locals.tmp("ret");
+                    self.src.push_str(&result);
+                    results.push(result);
+                }
+                if func.results.len() > 0 {
+                    self.src.push_str(" = ");
+                }
+                match &func.kind {
+                    FunctionKind::Freestanding | FunctionKind::Static { .. } => {
+                        self.src.push_str(&format!(
+                            "host.{}({})",
+                            func.name.to_snake_case(),
+                            operands.join(", "),
+                        ));
+                    }
+                    FunctionKind::Method { name, .. } => {
+                        self.src.push_str(&format!(
+                            "{}.{}({})",
+                            operands[0],
+                            name.to_snake_case(),
+                            operands[1..].join(", "),
+                        ));
+                    }
+                }
+                self.src.push_str("\n");
+            }
+
+            Instruction::Return { amt, .. } => match amt {
+                0 => {}
+                1 => self.src.push_str(&format!("return {}\n", operands[0])),
+                _ => {
+                    self.src
+                        .push_str(&format!("return ({})\n", operands.join(", ")));
+                }
+            },
+
+            Instruction::I32Load { offset } => self.load("c_int32", *offset, operands, results),
+            Instruction::I64Load { offset } => self.load("c_int64", *offset, operands, results),
+            Instruction::F32Load { offset } => self.load("c_float", *offset, operands, results),
+            Instruction::F64Load { offset } => self.load("c_double", *offset, operands, results),
+            Instruction::I32Load8U { offset } => self.load("c_uint8", *offset, operands, results),
+            Instruction::I32Load8S { offset } => self.load("c_int8", *offset, operands, results),
+            Instruction::I32Load16U { offset } => self.load("c_uint16", *offset, operands, results),
+            Instruction::I32Load16S { offset } => self.load("c_int16", *offset, operands, results),
+            Instruction::I32Store { offset } => self.store("c_uint32", *offset, operands),
+            Instruction::I64Store { offset } => self.store("c_uint64", *offset, operands),
+            Instruction::F32Store { offset } => self.store("c_float", *offset, operands),
+            Instruction::F64Store { offset } => self.store("c_double", *offset, operands),
+            Instruction::I32Store8 { offset } => self.store("c_uint8", *offset, operands),
+            Instruction::I32Store16 { offset } => self.store("c_uint16", *offset, operands),
+
+            Instruction::Witx { instr } => match instr {
+                WitxInstruction::PointerFromI32 { .. } => results.push(operands[0].clone()),
+                i => unimplemented!("{:?}", i),
+            },
+            i => unimplemented!("{:?}", i),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Source {
+    s: String,
+    indent: usize,
+}
+
+impl Source {
+    pub fn push_str(&mut self, src: &str) {
+        let lines = src.lines().collect::<Vec<_>>();
+        let mut trim = None;
+        for (i, line) in lines.iter().enumerate() {
+            self.s.push_str(if lines.len() == 1 {
+                line
+            } else {
+                let trim = match trim {
+                    Some(n) => n,
+                    None => {
+                        let val = line.len() - line.trim_start().len();
+                        if !line.is_empty() {
+                            trim = Some(val);
+                        }
+                        val
+                    }
+                };
+                line.get(trim..).unwrap_or("")
+            });
+            if i != lines.len() - 1 || src.ends_with("\n") {
+                self.newline();
+            }
+        }
+    }
+
+    pub fn indent(&mut self, amt: usize) {
+        self.indent += amt;
+        for _ in 0..amt {
+            self.s.push_str("  ");
+        }
+    }
+
+    pub fn deindent(&mut self, amt: usize) {
+        self.indent -= amt;
+        for _ in 0..amt {
+            assert!(self.s.ends_with("  "));
+            self.s.pop();
+            self.s.pop();
+        }
+    }
+
+    fn newline(&mut self) {
+        self.s.push_str("\n");
+        for _ in 0..self.indent {
+            self.s.push_str("  ");
+        }
+    }
+}
+
+impl std::ops::Deref for Source {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.s
+    }
+}
+
+impl From<Source> for String {
+    fn from(s: Source) -> String {
+        s.s
+    }
+}
+
+fn wasm_ty_ctor(ty: WasmType) -> &'static str {
+    match ty {
+        WasmType::I32 => "wasmtime.ValType.i32()",
+        WasmType::I64 => "wasmtime.ValType.i64()",
+        WasmType::F32 => "wasmtime.ValType.f32()",
+        WasmType::F64 => "wasmtime.ValType.f64()",
+    }
+}
+
+fn wasm_ty_typing(ty: WasmType) -> &'static str {
+    match ty {
+        WasmType::I32 => "int",
+        WasmType::I64 => "int",
+        WasmType::F32 => "float",
+        WasmType::F64 => "float",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Source;
+
+    #[test]
+    fn simple_append() {
+        let mut s = Source::default();
+        s.push_str("x");
+        assert_eq!(s.s, "x");
+        s.push_str("y");
+        assert_eq!(s.s, "xy");
+        s.push_str("z ");
+        assert_eq!(s.s, "xyz ");
+        s.push_str(" a ");
+        assert_eq!(s.s, "xyz  a ");
+        s.push_str("\na");
+        assert_eq!(s.s, "xyz  a \na");
+    }
+
+    #[test]
+    fn trim_ws() {
+        let mut s = Source::default();
+        s.push_str("def foo():\n  return 1\n");
+        assert_eq!(s.s, "def foo():\n  return 1\n");
+    }
+}

--- a/crates/gen-wasmtime-py/tests/check.rs
+++ b/crates/gen-wasmtime-py/tests/check.rs
@@ -1,0 +1,46 @@
+use std::path::Path;
+use std::process::Command;
+
+mod imports {
+    test_codegen::py_import!(
+        "*.witx"
+
+        // The python generator doesn't support the legacy witx features at this
+        // time.
+        "!legacy.witx"
+        "!wasi_snapshot_preview1.witx"
+    );
+}
+
+mod exports {
+    test_codegen::py_export!(
+        "*.witx"
+
+        // This uses buffers, which we don't support in exports just yet
+        // TODO: should support this
+        "!wasi_next.witx"
+        "!host.witx"
+    );
+}
+
+fn verify(dir: &str, _name: &str) {
+    let output = Command::new("mypy")
+        .arg(Path::new(dir).join("bindings.py"))
+        .arg("--config-file")
+        .arg("mypy.ini")
+        .output()
+        .unwrap();
+    if output.status.success() {
+        return;
+    }
+    println!("status: {}", output.status);
+    println!(
+        "stdout ---\n  {}",
+        String::from_utf8_lossy(&output.stdout).replace("\n", "\n  ")
+    );
+    println!(
+        "stderr ---\n  {}",
+        String::from_utf8_lossy(&output.stderr).replace("\n", "\n  ")
+    );
+    panic!("no success");
+}

--- a/crates/gen-wasmtime-py/tests/run.py
+++ b/crates/gen-wasmtime-py/tests/run.py
@@ -1,0 +1,644 @@
+from dataclasses import dataclass
+from exports.bindings import Wasm
+from imports.bindings import add_host_to_linker, Host, Expected
+from typing import Tuple, Optional, List
+import exports.bindings as e
+import imports.bindings as i
+import math
+import sys
+import wasmtime
+
+
+@dataclass
+class HostState(i.HostState):
+    val: int
+
+
+HOST_STATE2_CLOSED = False
+
+
+@dataclass
+class HostState2(i.HostState2):
+    val: int
+
+    def drop(self) -> None:
+        global HOST_STATE2_CLOSED
+        HOST_STATE2_CLOSED = True
+
+
+@dataclass
+class Markdown(i.Markdown2):
+    buf: str = ''
+
+    def append(self, data: str) -> None:
+        self.buf += data
+
+    def render(self) -> str:
+        return self.buf.replace('red', 'green')
+
+
+class HostImpl(Host):
+    def roundtrip_u8(self, a: int) -> int:
+        return a
+
+    def roundtrip_s8(self, a: int) -> int:
+        return a
+
+    def roundtrip_u16(self, a: int) -> int:
+        return a
+
+    def roundtrip_s16(self, a: int) -> int:
+        return a
+
+    def roundtrip_u32(self, a: int) -> int:
+        return a
+
+    def roundtrip_s32(self, a: int) -> int:
+        return a
+
+    def roundtrip_u64(self, a: int) -> int:
+        return a
+
+    def roundtrip_s64(self, a: int) -> int:
+        return a
+
+    def roundtrip_f32(self, a: float) -> float:
+        return a
+
+    def roundtrip_f64(self, a: float) -> float:
+        return a
+
+    def roundtrip_char(self, a: str) -> str:
+        return a
+
+    def multiple_results(self) -> Tuple[int, int]:
+        return (4, 5)
+
+    def set_scalar(self, a: int) -> None:
+        self.scalar = a
+
+    def get_scalar(self) -> int:
+        return self.scalar
+
+    def swap_tuple(self, a: Tuple[int, int]) -> Tuple[int, int]:
+        return (a[1], a[0])
+
+    def roundtrip_flags1(self, a: i.F1) -> i.F1:
+        return a
+
+    def roundtrip_flags2(self, a: i.F2) -> i.F2:
+        return a
+
+    def roundtrip_flags3(self, a: i.Flag8, b: i.Flag16, c: i.Flag32, d: i.Flag64) -> Tuple[i.Flag8, i.Flag16, i.Flag32, i.Flag64]:
+        return (a, b, c, d)
+
+    def roundtrip_record1(self, a: i.R1) -> i.R1:
+        return a
+
+    def tuple0(self, a: None) -> None:
+        pass
+
+    def tuple1(self, a: Tuple[int]) -> Tuple[int]:
+        return (a[0],)
+
+    def roundtrip_option(self, a: Optional[float]) -> Optional[int]:
+        if a:
+            return int(a)
+        return None
+
+    def roundtrip_result(self, a: i.Expected[int, float]) -> i.Expected[float, int]:
+        if isinstance(a, i.Ok):
+            return i.Ok(float(a.value))
+        return i.Err(int(a.value))
+
+    def roundtrip_enum(self, a: i.E1) -> i.E1:
+        return a
+
+    def invert_bool(self, a: bool) -> bool:
+        return not a
+
+    def variant_casts(self, a: i.Casts) -> i.Casts:
+        return a
+
+    def variant_zeros(self, a: i.Zeros) -> i.Zeros:
+        return a
+
+    def variant_typedefs(self, a: i.OptionTypedef, b: i.BoolTypedef, c: i.ResultTypedef) -> None:
+        pass
+
+    def variant_enums(self, a: bool, b: Expected[None, None], c: i.MyErrno) -> Tuple[bool, Expected[None, None], i.MyErrno]:
+        assert(a)
+        assert(isinstance(b, i.Ok))
+        assert(c == i.MyErrno.SUCCESS)
+        return (False, i.Err(None), i.MyErrno.A)
+
+    def list_param(self, a: bytes) -> None:
+        assert(a == b'\x01\x02\x03\x04')
+
+    def list_param2(self, a: str) -> None:
+        assert(a == 'foo')
+
+    def list_param3(self, a: List[str]) -> None:
+        assert(a == ['foo', 'bar', 'baz'])
+
+    def list_param4(self, a: List[List[str]]) -> None:
+        assert(a == [['foo', 'bar'], ['baz']])
+
+    def list_result(self) -> bytes:
+        return b'\x01\x02\x03\x04\x05'
+
+    def list_result2(self) -> str:
+        return 'hello!'
+
+    def list_result3(self) -> List[str]:
+        return ['hello,', 'world!']
+
+    def string_roundtrip(self, a: str) -> str:
+        return a
+
+    def unaligned_roundtrip1(self, a: List[int], b: List[int], c: List[int], d: List[i.Flag32], e: List[i.Flag64]) -> None:
+        assert(a == [1])
+        assert(b == [2])
+        assert(c == [3])
+        assert(d == [i.Flag32.B8])
+        assert(e == [i.Flag64.B9])
+
+    def unaligned_roundtrip2(self, a: List[i.UnalignedRecord], b: List[float], c: List[float], d: List[str], e: List[bytes]) -> None:
+          assert(a == [i.UnalignedRecord(a=10, b=11)])
+          assert(b == [100.0])
+          assert(c == [101.0])
+          assert(d == ['foo'])
+          assert(e == [b'\x66'])
+
+    def list_minmax8(self, a: bytes, b: List[int]) -> Tuple[bytes, List[int]]:
+        assert(a == b'\x00\xff')
+        assert(b == [-(1 << (8 - 1)), (1 << (8 - 1)) - 1])
+        return (a, b)
+
+    def list_minmax16(self, a: List[int], b: List[int]) -> Tuple[List[int], List[int]]:
+        assert(a == [0, (1 << 16) - 1])
+        assert(b == [-(1 << (16 - 1)), (1 << (16 - 1)) - 1])
+        return (a, b)
+
+    def list_minmax32(self, a: List[int], b: List[int]) -> Tuple[List[int], List[int]]:
+        assert(a == [0, (1 << 32) - 1])
+        assert(b == [-(1 << (32 - 1)), (1 << (32 - 1)) - 1])
+        return (a, b)
+
+    def list_minmax64(self, a: List[int], b: List[int]) -> Tuple[List[int], List[int]]:
+        assert(a == [0, (1 << 64) - 1])
+        assert(b == [-(1 << (64 - 1)), (1 << (64 - 1)) - 1])
+        return (a, b)
+
+    def list_minmax_float(self, a: List[float], b: List[float]) -> Tuple[List[float], List[float]]:
+        assert(a == [-3.4028234663852886e+38, 3.4028234663852886e+38, -float('inf'), float('inf')])
+        assert(b == [-sys.float_info.max, sys.float_info.max, -float('inf'), float('inf')])
+        return (a, b)
+
+    def host_state_create(self) -> i.HostState:
+        return HostState(100)
+
+    def host_state_get(self, a: i.HostState) -> int:
+        assert(isinstance(a, HostState))
+        return a.val
+
+    def host_state2_create(self) -> i.HostState2:
+        return HostState2(101)
+
+    def host_state2_saw_close(self) -> bool:
+        return HOST_STATE2_CLOSED
+
+    def two_host_states(self, a: i.HostState, b: i.HostState2) -> Tuple[i.HostState, i.HostState2]:
+        return (b, a)
+
+    def host_state2_param_record(self, a: i.HostStateParamRecord) -> None:
+        pass
+
+    def host_state2_param_tuple(self, a: i.HostStateParamTuple) -> None:
+        pass
+
+    def host_state2_param_option(self, a: i.HostStateParamOption) -> None:
+        pass
+
+    def host_state2_param_result(self, a: i.HostStateParamResult) -> None:
+        pass
+
+    def host_state2_param_variant(self, a: i.HostStateParamVariant) -> None:
+        pass
+
+    def host_state2_param_list(self, a: List[i.HostState2]) -> None:
+        pass
+
+    def host_state2_result_record(self) -> i.HostStateResultRecord:
+        return i.HostStateResultRecord(HostState(2))
+
+    def host_state2_result_tuple(self) -> i.HostStateResultTuple:
+        return (HostState(2),)
+
+    def host_state2_result_option(self) -> i.HostStateResultOption:
+        return HostState(2)
+
+    def host_state2_result_result(self) -> i.HostStateResultResult:
+        return i.Ok(HostState2(2))
+
+    def host_state2_result_variant(self) -> i.HostStateResultVariant:
+        return i.HostStateResultVariant0(HostState2(2))
+
+    def host_state2_result_list(self) -> List[i.HostState2]:
+        return [HostState2(2), HostState2(5)]
+
+    def markdown2_create(self) -> i.Markdown2:
+        return Markdown()
+
+    def buffer_u8(self, a: i.PullBuffer[int], b: i.PushBuffer[int]) -> int:
+        assert(len(a) == 1)
+        assert(len(b) == 10)
+        assert(a.pull() == 0)
+        assert(a.pull() == None)
+        b.push(1)
+        b.push(2)
+        b.push(3)
+        return 3
+
+    def buffer_u32(self, a: i.PullBuffer[int], b: i.PushBuffer[int]) -> int:
+        assert(len(a) == 1)
+        assert(len(b) == 10)
+        assert(a.pull() == 0)
+        assert(a.pull() == None)
+        b.push(1)
+        b.push(2)
+        b.push(3)
+        return 3
+
+    def buffer_bool(self, a: i.PullBuffer[bool], b: i.PushBuffer[bool]) -> int:
+        assert(len(a) <= len(b))
+        n = 0
+        while True:
+            val = a.pull()
+            if val is None:
+                break
+            b.push(not val)
+            n += 1
+        return n
+
+    def buffer_mutable1(self, x: List[i.PullBuffer[bool]]) -> None:
+        assert(len(x) == 1)
+        assert(len(x[0]) == 5)
+        assert(x[0].pull() == True)
+        assert(x[0].pull() == False)
+        assert(x[0].pull() == True)
+        assert(x[0].pull() == True)
+        assert(x[0].pull() == False)
+        assert(x[0].pull() == None)
+
+    def buffer_mutable2(self, a: List[i.PushBuffer[int]]) -> int:
+        assert(len(a) == 1)
+        assert(len(a[0]) > 4)
+        a[0].push(1)
+        a[0].push(2)
+        a[0].push(3)
+        a[0].push(4)
+        return 4
+
+    def buffer_mutable3(self, a: List[i.PushBuffer[bool]]) -> int:
+        assert(len(a) == 1)
+        assert(len(a[0]) > 3)
+        a[0].push(False)
+        a[0].push(True)
+        a[0].push(False)
+        return 3
+
+    def buffer_in_record(self, a: i.BufferInRecord) -> None:
+        pass
+
+    def buffer_typedef(self, a: i.ParamInBufferU8, b: i.ParamOutBufferU8, c: i.ParamInBufferBool, d: i.ParamOutBufferBool) -> None:
+        pass
+
+    def list_in_record1(self, a: i.ListInRecord1) -> None:
+        pass
+
+    def list_in_record2(self) -> i.ListInRecord2:
+        return i.ListInRecord2('list_in_record2')
+
+    def list_in_record3(self, a: i.ListInRecord3) -> i.ListInRecord3:
+        assert(a.a == 'list_in_record3 input')
+        return i.ListInRecord3('list_in_record3 output')
+
+    def list_in_record4(self, a: i.ListInAlias) -> i.ListInAlias:
+        assert(a.a == 'input4')
+        return i.ListInRecord4('result4')
+
+    def list_in_variant1(self, a: i.ListInVariant11, b: i.ListInVariant12, c: i.ListInVariant13) -> None:
+        assert(a == 'foo')
+        assert(b == i.Err('bar'))
+        assert(c == i.ListInVariant130('baz'))
+
+    def list_in_variant2(self) -> i.ListInVariant2:
+        return 'list_in_variant2'
+
+    def list_in_variant3(self, a: i.ListInVariant3) -> i.ListInVariant3:
+        assert(a == 'input3')
+        return 'output3'
+
+    def errno_result(self) -> i.Expected[None, i.MyErrno]:
+        return i.Err(i.MyErrno.B)
+
+    def list_typedefs(self, a: i.ListTypedef, c: i.ListTypedef3) -> Tuple[i.ListTypedef2, i.ListTypedef3]:
+        assert(a == 'typedef1')
+        assert(c == ['typedef2'])
+        return (b'typedef3', ['typedef4'])
+
+    def list_of_variants(self, a: List[bool], b: List[i.Expected[None, None]], c: List[i.MyErrno]) -> Tuple[List[bool], List[i.Expected[None, None]], List[i.MyErrno]]:
+          assert(a == [True, False])
+          assert(b == [i.Ok(None), i.Err(None)])
+          assert(c == [i.MyErrno.SUCCESS, i.MyErrno.A])
+          return (
+                [False, True],
+                [i.Err(None), i.Ok(None)],
+                [i.MyErrno.A, i.MyErrno.B],
+          )
+
+
+def run(wasm_file: str) -> None:
+    print('Running', wasm_file)
+    store = wasmtime.Store()
+    module = wasmtime.Module.from_file(store.engine, wasm_file)
+    linker = wasmtime.Linker(store.engine)
+    linker.define_wasi()
+    wasi = wasmtime.WasiConfig()
+    wasi.inherit_stdout()
+    wasi.inherit_stderr()
+    store.set_wasi(wasi)
+
+    # Define state imported from python and register it with our linker
+    host = HostImpl()
+    add_host_to_linker(linker, store, host)
+
+    # Using the linker, instantiate the module and wrap it up in the export
+    # bindings.
+    wasm = Wasm(store, linker, module)
+
+    # Run all the tests!
+
+    allocated_bytes = wasm.allocated_bytes(store)
+    wasm.run_import_tests(store)
+    test_scalars(wasm, store)
+    test_records(wasm, store)
+    test_variants(wasm, store)
+    test_lists(wasm, store)
+    test_flavorful(wasm, store)
+    test_invalid(wasm, store)
+    test_handles(wasm, store)
+
+    # Ensure that we properly called `free` everywhere in all the glue that we
+    # needed to.
+    assert(allocated_bytes == wasm.allocated_bytes(store))
+
+
+def test_scalars(wasm: Wasm, store: wasmtime.Store) -> None:
+    assert(wasm.roundtrip_u8(store, 1) == 1)
+    assert(wasm.roundtrip_u8(store, (1 << 8) - 1) == (1 << 8) - 1)
+    assert(wasm.roundtrip_u16(store, 1) == 1)
+    assert(wasm.roundtrip_u16(store, (1 << 16) - 1) == (1 << 16) - 1)
+    assert(wasm.roundtrip_u32(store, 1) == 1)
+    assert(wasm.roundtrip_u32(store, (1 << 32) - 1) == (1 << 32) - 1)
+    assert(wasm.roundtrip_u64(store, 1) == 1)
+    assert(wasm.roundtrip_u64(store, (1 << 64) - 1) == (1 << 64) - 1)
+
+    assert(wasm.roundtrip_s8(store, 1) == 1)
+    assert(wasm.roundtrip_s8(store, (1 << (8 - 1) - 1)) == (1 << (8 - 1) - 1))
+    assert(wasm.roundtrip_s8(store, -(1 << (8 - 1))) == -(1 << (8 - 1)))
+    assert(wasm.roundtrip_s16(store, 1) == 1)
+    assert(wasm.roundtrip_s16(store, (1 << (16 - 1) - 1)) == (1 << (16 - 1) - 1))
+    assert(wasm.roundtrip_s16(store, -(1 << (16 - 1))) == -(1 << (16 - 1)))
+    assert(wasm.roundtrip_s32(store, 1) == 1)
+    assert(wasm.roundtrip_s32(store, (1 << (32 - 1) - 1)) == (1 << (32 - 1) - 1))
+    assert(wasm.roundtrip_s32(store, -(1 << (32 - 1))) == -(1 << (32 - 1)))
+    assert(wasm.roundtrip_s64(store, 1) == 1)
+    assert(wasm.roundtrip_s64(store, (1 << (64 - 1) - 1)) == (1 << (64 - 1) - 1))
+    assert(wasm.roundtrip_s64(store, -(1 << (64 - 1))) == -(1 << (64 - 1)))
+
+    assert(wasm.multiple_results(store) == (100, 200))
+
+    inf = float('inf')
+    assert(wasm.roundtrip_f32(store, 1.0) == 1.0)
+    assert(wasm.roundtrip_f32(store, inf) == inf)
+    assert(wasm.roundtrip_f32(store, -inf) == -inf)
+    assert(math.isnan(wasm.roundtrip_f32(store, float('nan'))))
+
+    assert(wasm.roundtrip_f64(store, 1.0) == 1.0)
+    assert(wasm.roundtrip_f64(store, inf) == inf)
+    assert(wasm.roundtrip_f64(store, -inf) == -inf)
+    assert(math.isnan(wasm.roundtrip_f64(store, float('nan'))))
+
+    assert(wasm.roundtrip_char(store, 'a') == 'a')
+    assert(wasm.roundtrip_char(store, ' ') == ' ')
+    assert(wasm.roundtrip_char(store, '🚩') == '🚩')
+
+    wasm.set_scalar(store, 2)
+    assert(wasm.get_scalar(store) == 2)
+    wasm.set_scalar(store, 4)
+    assert(wasm.get_scalar(store) == 4)
+
+
+def test_records(wasm: Wasm, store: wasmtime.Store) -> None:
+    assert(wasm.swap_tuple(store, (1, 2)) == (2, 1))
+    assert(wasm.roundtrip_flags1(store, e.F1.A) == e.F1.A)
+    assert(wasm.roundtrip_flags1(store, e.F1(0)) == e.F1(0))
+    assert(wasm.roundtrip_flags1(store, e.F1.A | e.F1.B) == (e.F1.A | e.F1.B))
+
+    assert(wasm.roundtrip_flags2(store, e.F2.C) == e.F2.C)
+    assert(wasm.roundtrip_flags2(store, e.F2(0)) == e.F2(0))
+    assert(wasm.roundtrip_flags2(store, e.F2.D) == e.F2.D)
+    assert(wasm.roundtrip_flags2(store, e.F2.C | e.F2.E) == (e.F2.C | e.F2.E))
+
+    r = wasm.roundtrip_record1(store, e.R1(8, e.F1(0)))
+    assert(r.a == 8)
+    assert(r.b == e.F1(0))
+
+    r = wasm.roundtrip_record1(store, e.R1(a=0, b=e.F1.A | e.F1.B))
+    assert(r.a == 0)
+    assert(r.b == (e.F1.A | e.F1.B))
+
+    wasm.tuple0(store, None)
+    assert(wasm.tuple1(store, (1,)) == (1,))
+
+
+def test_variants(wasm: Wasm, store: wasmtime.Store) -> None:
+    assert(wasm.roundtrip_option(store, 1.) == 1)
+    assert(wasm.roundtrip_option(store, None) == None)
+    assert(wasm.roundtrip_option(store, 2.) == 2)
+    assert(wasm.roundtrip_result(store, e.Ok(2)) == e.Ok(2))
+    assert(wasm.roundtrip_result(store, e.Ok(4)) == e.Ok(4))
+    assert(wasm.roundtrip_result(store, e.Err(5)) == e.Err(5))
+
+    assert(wasm.roundtrip_enum(store, e.E1.A) == e.E1.A)
+    assert(wasm.roundtrip_enum(store, e.E1.B) == e.E1.B)
+
+    assert(wasm.invert_bool(store, True) == False)
+    assert(wasm.invert_bool(store, False) == True)
+
+    a1, a2, a3, a4, a5, a6 = wasm.variant_casts(store, (
+        e.C1A(1),
+        e.C2A(2),
+        e.C3A(3),
+        e.C4A(4),
+        e.C5A(5),
+        e.C6A(6.),
+    ))
+    assert(a1 == e.C1A(1))
+    assert(a2 == e.C2A(2))
+    assert(a3 == e.C3A(3))
+    assert(a4 == e.C4A(4))
+    assert(a5 == e.C5A(5))
+    assert(a6 == e.C6A(6))
+
+    b1, b2, b3, b4, b5, b6 = wasm.variant_casts(store, (
+        e.C1B(1),
+        e.C2B(2),
+        e.C3B(3),
+        e.C4B(4),
+        e.C5B(5),
+        e.C6B(6.),
+    ))
+    assert(b1 == e.C1B(1))
+    assert(b2 == e.C2B(2))
+    assert(b3 == e.C3B(3))
+    assert(b4 == e.C4B(4))
+    assert(b5 == e.C5B(5))
+    assert(b6 == e.C6B(6))
+
+    z1, z2, z3, z4 = wasm.variant_zeros(store, (
+        e.Z1A(1),
+        e.Z2A(2),
+        e.Z3A(3.),
+        e.Z4A(4.),
+    ))
+    assert(z1 == e.Z1A(1))
+    assert(z2 == e.Z2A(2))
+    assert(z3 == e.Z3A(3))
+    assert(z4 == e.Z4A(4))
+
+    wasm.variant_typedefs(store, None, False, e.Err(None))
+
+
+def test_lists(wasm: Wasm, store: wasmtime.Store) -> None:
+    wasm.list_param(store, b'\x01\x02\x03\x04')
+    wasm.list_param2(store, "foo")
+    wasm.list_param3(store, ["foo", "bar", "baz"])
+    wasm.list_param4(store, [["foo", "bar"], ["baz"]])
+    assert(wasm.list_result(store) == b'\x01\x02\x03\x04\x05')
+    assert(wasm.list_result2(store) == "hello!")
+    assert(wasm.list_result3(store) == ["hello,", "world!"])
+
+    assert(wasm.string_roundtrip(store, "x") == "x")
+    assert(wasm.string_roundtrip(store, "") == "")
+    assert(wasm.string_roundtrip(store, "hello ⚑ world") == "hello ⚑ world")
+
+
+def test_flavorful(wasm: Wasm, store: wasmtime.Store) -> None:
+    wasm.list_in_record1(store, e.ListInRecord1("list_in_record1"))
+    assert(wasm.list_in_record2(store) == e.ListInRecord2(a="list_in_record2"))
+
+    assert(wasm.list_in_record3(store, e.ListInRecord3("list_in_record3 input")).a == "list_in_record3 output")
+    assert(wasm.list_in_record4(store, e.ListInRecord4("input4")).a == "result4")
+
+    wasm.list_in_variant1(store, "foo", e.Err("bar"), e.ListInVariant130('baz'))
+    assert(wasm.list_in_variant2(store) == "list_in_variant2")
+    assert(wasm.list_in_variant3(store, "input3") == "output3")
+
+    assert(isinstance(wasm.errno_result(store), e.Err))
+
+    r1, r2 = wasm.list_typedefs(store, "typedef1", ["typedef2"])
+    assert(r1 == b'typedef3')
+    assert(r2 == ['typedef4'])
+
+
+def test_invalid(wasm: Wasm, store: wasmtime.Store) -> None:
+    def assert_throws(name: str, msg: str) -> None:
+        export = wasm.instance.exports(store)[name]
+        assert(isinstance(export, wasmtime.Func))
+        try:
+            export(store)
+            raise RuntimeError('expected exception')
+        except TypeError as e:
+            actual = str(e)
+        except OverflowError as e:
+            actual = str(e)
+        except ValueError as e:
+            actual = str(e)
+        except IndexError as e:
+            actual = str(e)
+        if not msg in actual:
+            print(actual)
+            assert(msg in actual)
+
+    assert_throws('invalid_bool', 'invalid variant discriminant for bool')
+    assert_throws('invalid_u8', 'must be between')
+    assert_throws('invalid_s8', 'must be between')
+    assert_throws('invalid_u16', 'must be between')
+    assert_throws('invalid_s16', 'must be between')
+    assert_throws('invalid_char', 'not a valid char')
+    assert_throws('invalid_e1', 'not a valid E1')
+    assert_throws('invalid_handle', 'handle index not valid')
+    assert_throws('invalid_handle_close', 'handle index not valid')
+
+
+def test_handles(wasm: Wasm, store: wasmtime.Store) -> None:
+    # Param/result of a handle works in a simple fashion
+    s: e.WasmState = wasm.wasm_state_create(store)
+    assert(wasm.wasm_state_get_val(store, s) == 100)
+
+    # Deterministic destruction is possible
+    assert(wasm.wasm_state2_saw_close(store) == False)
+    s2: e.WasmState2 = wasm.wasm_state2_create(store)
+    assert(wasm.wasm_state2_saw_close(store) == False)
+    s2.drop(store)
+    assert(wasm.wasm_state2_saw_close(store) == True)
+
+    arg1 = wasm.wasm_state_create(store)
+    arg2 = wasm.wasm_state2_create(store)
+    c, d = wasm.two_wasm_states(store, arg1, arg2)
+    arg1.drop(store)
+    arg2.drop(store)
+
+    wasm.wasm_state2_param_record(store, e.WasmStateParamRecord(d))
+    wasm.wasm_state2_param_tuple(store, (d,))
+    wasm.wasm_state2_param_option(store, d)
+    wasm.wasm_state2_param_option(store, None)
+    wasm.wasm_state2_param_result(store, e.Ok(d))
+    wasm.wasm_state2_param_result(store, e.Err(2))
+    wasm.wasm_state2_param_variant(store, e.WasmStateParamVariant0(d))
+    wasm.wasm_state2_param_variant(store, e.WasmStateParamVariant1(2))
+    wasm.wasm_state2_param_list(store, [])
+    wasm.wasm_state2_param_list(store, [d])
+    wasm.wasm_state2_param_list(store, [d, d])
+
+    c.drop(store)
+    d.drop(store)
+
+    wasm.wasm_state2_result_record(store).a.drop(store)
+    wasm.wasm_state2_result_tuple(store)[0].drop(store)
+    opt = wasm.wasm_state2_result_option(store)
+    assert(opt is not None)
+    opt.drop(store)
+    result = wasm.wasm_state2_result_result(store)
+    assert(isinstance(result, e.Ok))
+    result.value.drop(store)
+    variant = wasm.wasm_state2_result_variant(store)
+    print(variant)
+    assert(isinstance(variant, e.WasmStateResultVariant0))
+    variant.value.drop(store)
+    for val in wasm.wasm_state2_result_list(store):
+        val.drop(store)
+
+    s.drop(store)
+
+    md = e.Markdown.create(store, wasm)
+    if md:
+        md.append(store, "red is the best color")
+        assert(md.render(store) == "green is the best color")
+        md.drop(store)
+
+if __name__ == '__main__':
+    run(sys.argv[1])

--- a/crates/gen-wasmtime-py/tests/run.rs
+++ b/crates/gen-wasmtime-py/tests/run.rs
@@ -1,0 +1,75 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use witx_bindgen_gen_core::witx2::abi::Direction;
+use witx_bindgen_gen_core::Generator;
+
+#[test]
+fn run() {
+    let mut dir = PathBuf::from(env!("OUT_DIR"));
+    dir.push("run");
+    drop(fs::remove_dir_all(&dir));
+    fs::create_dir_all(&dir).unwrap();
+    fs::create_dir_all(&dir.join("imports")).unwrap();
+    fs::create_dir_all(&dir.join("exports")).unwrap();
+
+    println!("OUT_DIR = {:?}", dir);
+    println!("Generating bindings...");
+    let iface =
+        witx_bindgen_gen_core::witx2::Interface::parse_file("../../tests/host.witx").unwrap();
+    let mut files = Default::default();
+    witx_bindgen_gen_wasmtime_py::Opts::default()
+        .build()
+        .generate(&iface, Direction::Import, &mut files);
+    for (file, contents) in files.iter() {
+        fs::write(dir.join("imports").join(file), contents).unwrap();
+    }
+    fs::write(dir.join("imports").join("__init__.py"), "").unwrap();
+
+    let iface =
+        witx_bindgen_gen_core::witx2::Interface::parse_file("../../tests/wasm.witx").unwrap();
+    let mut files = Default::default();
+    witx_bindgen_gen_wasmtime_py::Opts::default()
+        .build()
+        .generate(&iface, Direction::Export, &mut files);
+    for (file, contents) in files.iter() {
+        fs::write(dir.join("exports").join(file), contents).unwrap();
+    }
+    fs::write(dir.join("exports").join("__init__.py"), "").unwrap();
+
+    println!("Running mypy...");
+    exec(
+        Command::new("mypy")
+            .env("MYPYPATH", &dir)
+            .arg("tests/run.py"),
+    );
+
+    for (_name, wasm) in build_test_wasm::WASMS {
+        println!("Running {}...", wasm);
+        exec(
+            Command::new("python3")
+                .env("PYTHONPATH", &dir)
+                .arg("tests/run.py")
+                .arg(wasm),
+        );
+    }
+}
+
+fn exec(cmd: &mut Command) {
+    println!("{:?}", cmd);
+    let output = cmd.output().unwrap();
+    if output.status.success() {
+        return;
+    }
+    println!("status: {}", output.status);
+    println!(
+        "stdout ---\n  {}",
+        String::from_utf8_lossy(&output.stdout).replace("\n", "\n  ")
+    );
+    println!(
+        "stderr ---\n  {}",
+        String::from_utf8_lossy(&output.stderr).replace("\n", "\n  ")
+    );
+    panic!("no success");
+}

--- a/crates/test-codegen/Cargo.toml
+++ b/crates/test-codegen/Cargo.toml
@@ -19,6 +19,7 @@ quote = "1.0.9"
 witx-bindgen-gen-core = { path = '../gen-core' }
 witx-bindgen-gen-rust-wasm = { path = '../gen-rust-wasm', optional = true }
 witx-bindgen-gen-wasmtime = { path = '../gen-wasmtime', optional = true }
+witx-bindgen-gen-wasmtime-py = { path = '../gen-wasmtime-py', optional = true }
 witx-bindgen-gen-js = { path = '../gen-js', optional = true }
 witx-bindgen-gen-c = { path = '../gen-c', optional = true }
 witx2 = { path = '../witx2', features = ['old-witx-compat'] }

--- a/crates/test-codegen/src/lib.rs
+++ b/crates/test-codegen/src/lib.rs
@@ -307,6 +307,22 @@ pub fn c_export(input: TokenStream) -> TokenStream {
     })
 }
 
+#[proc_macro]
+#[cfg(feature = "witx-bindgen-gen-wasmtime-py")]
+pub fn py_import(input: TokenStream) -> TokenStream {
+    gen_verify(input, Direction::Import, "import", || {
+        witx_bindgen_gen_wasmtime_py::Opts::default().build()
+    })
+}
+
+#[proc_macro]
+#[cfg(feature = "witx-bindgen-gen-wasmtime-py")]
+pub fn py_export(input: TokenStream) -> TokenStream {
+    gen_verify(input, Direction::Export, "export", || {
+        witx_bindgen_gen_wasmtime_py::Opts::default().build()
+    })
+}
+
 fn generate_tests<G>(
     input: TokenStream,
     dir: &str,

--- a/crates/test-rust-wasm/src/imports.rs
+++ b/crates/test-rust-wasm/src/imports.rs
@@ -256,6 +256,33 @@ fn host_lists() {
             &*lists.as_slice(),
         );
     }
+
+    assert_eq!(
+        list_minmax8(&[u8::MIN, u8::MAX], &[i8::MIN, i8::MAX]),
+        (vec![u8::MIN, u8::MAX], vec![i8::MIN, i8::MAX]),
+    );
+    assert_eq!(
+        list_minmax16(&[u16::MIN, u16::MAX], &[i16::MIN, i16::MAX]),
+        (vec![u16::MIN, u16::MAX], vec![i16::MIN, i16::MAX]),
+    );
+    assert_eq!(
+        list_minmax32(&[u32::MIN, u32::MAX], &[i32::MIN, i32::MAX]),
+        (vec![u32::MIN, u32::MAX], vec![i32::MIN, i32::MAX]),
+    );
+    assert_eq!(
+        list_minmax64(&[u64::MIN, u64::MAX], &[i64::MIN, i64::MAX]),
+        (vec![u64::MIN, u64::MAX], vec![i64::MIN, i64::MAX]),
+    );
+    assert_eq!(
+        list_minmax_float(
+            &[f32::MIN, f32::MAX, f32::NEG_INFINITY, f32::INFINITY],
+            &[f64::MIN, f64::MAX, f64::NEG_INFINITY, f64::INFINITY]
+        ),
+        (
+            vec![f32::MIN, f32::MAX, f32::NEG_INFINITY, f32::INFINITY],
+            vec![f64::MIN, f64::MAX, f64::NEG_INFINITY, f64::INFINITY],
+        ),
+    );
 }
 
 fn host_flavorful() {

--- a/crates/wasmtime/src/le.rs
+++ b/crates/wasmtime/src/le.rs
@@ -94,6 +94,12 @@ impl<T: Endian + PartialEq> PartialEq for Le<T> {
     }
 }
 
+impl<T: Endian + PartialEq> PartialEq<T> for Le<T> {
+    fn eq(&self, other: &T) -> bool {
+        self.get() == *other
+    }
+}
+
 impl<T: Endian + Eq> Eq for Le<T> {}
 
 impl<T: Endian + PartialOrd> PartialOrd for Le<T> {

--- a/crates/wasmtime/tests/run/imports.rs
+++ b/crates/wasmtime/tests/run/imports.rs
@@ -444,9 +444,9 @@ impl Host for MyHost {
         flag32s: Vec<Flag32>,
         flag64s: Vec<Flag64>,
     ) {
-        assert_eq!(u16s, [1.into()]);
-        assert_eq!(u32s, [2.into()]);
-        assert_eq!(u64s, [3.into()]);
+        assert_eq!(u16s, [1]);
+        assert_eq!(u32s, [2]);
+        assert_eq!(u64s, [3]);
         assert_eq!(flag32s, [Flag32::B8]);
         assert_eq!(flag64s, [Flag64::B9]);
     }
@@ -462,8 +462,8 @@ impl Host for MyHost {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].get().a, 10);
         assert_eq!(records[0].get().b, 11);
-        assert_eq!(f32s, [100.0.into()]);
-        assert_eq!(f64s, [101.0.into()]);
+        assert_eq!(f32s, [100.0]);
+        assert_eq!(f64s, [101.0]);
         assert_eq!(strings, ["foo"]);
         assert_eq!(lists, [&[102][..]]);
     }
@@ -478,5 +478,47 @@ impl Host for MyHost {
 
     fn markdown2_render(&mut self, md: &Markdown) -> String {
         md.buf.borrow().replace("red", "green")
+    }
+
+    fn list_minmax8(&mut self, u: &[u8], s: &[i8]) -> (Vec<u8>, Vec<i8>) {
+        assert_eq!(u, [u8::MIN, u8::MAX]);
+        assert_eq!(s, [i8::MIN, i8::MAX]);
+        (u.to_vec(), s.to_vec())
+    }
+
+    fn list_minmax16(&mut self, u: &[Le<u16>], s: &[Le<i16>]) -> (Vec<u16>, Vec<i16>) {
+        assert_eq!(u, [u16::MIN, u16::MAX]);
+        assert_eq!(s, [i16::MIN, i16::MAX]);
+        (
+            u.iter().map(|e| e.get()).collect(),
+            s.iter().map(|e| e.get()).collect(),
+        )
+    }
+
+    fn list_minmax32(&mut self, u: &[Le<u32>], s: &[Le<i32>]) -> (Vec<u32>, Vec<i32>) {
+        assert_eq!(u, [u32::MIN, u32::MAX]);
+        assert_eq!(s, [i32::MIN, i32::MAX]);
+        (
+            u.iter().map(|e| e.get()).collect(),
+            s.iter().map(|e| e.get()).collect(),
+        )
+    }
+
+    fn list_minmax64(&mut self, u: &[Le<u64>], s: &[Le<i64>]) -> (Vec<u64>, Vec<i64>) {
+        assert_eq!(u, [u64::MIN, u64::MAX]);
+        assert_eq!(s, [i64::MIN, i64::MAX]);
+        (
+            u.iter().map(|e| e.get()).collect(),
+            s.iter().map(|e| e.get()).collect(),
+        )
+    }
+
+    fn list_minmax_float(&mut self, u: &[Le<f32>], s: &[Le<f64>]) -> (Vec<f32>, Vec<f64>) {
+        assert_eq!(u, [f32::MIN, f32::MAX, f32::NEG_INFINITY, f32::INFINITY]);
+        assert_eq!(s, [f64::MIN, f64::MAX, f64::NEG_INFINITY, f64::INFINITY]);
+        (
+            u.iter().map(|e| e.get()).collect(),
+            s.iter().map(|e| e.get()).collect(),
+        )
     }
 }

--- a/crates/witx-bindgen-demo/Cargo.toml
+++ b/crates/witx-bindgen-demo/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 witx-bindgen-gen-core = { path = '../gen-core', features = ['old-witx-compat'] }
 witx-bindgen-gen-rust-wasm = { path = '../gen-rust-wasm' }
 witx-bindgen-gen-wasmtime = { path = '../gen-wasmtime' }
+witx-bindgen-gen-wasmtime-py = { path = '../gen-wasmtime-py' }
 witx-bindgen-gen-js = { path = '../gen-js' }
 witx-bindgen-gen-c = { path = '../gen-c' }
 witx-bindgen-gen-markdown = { path = '../gen-markdown' }

--- a/crates/witx-bindgen-demo/demo.witx
+++ b/crates/witx-bindgen-demo/demo.witx
@@ -10,6 +10,7 @@ enum lang {
   js,
   rust,
   wasmtime,
+  wasmtime_py,
   c,
   markdown,
 }

--- a/crates/witx-bindgen-demo/index.html
+++ b/crates/witx-bindgen-demo/index.html
@@ -52,6 +52,7 @@ hello: function(who: person) -&gt; string
             <option value="js">JavaScript</option>
             <option value="rust">Rust</option>
             <option value="wasmtime">Wasmtime</option>
+            <option value="wasmtime-py">Wasmtime (Python)</option>
             <option value="c">C</option>
             <option value="markdown">Markdown</option>
           </select>
@@ -76,6 +77,8 @@ hello: function(who: person) -&gt; string
           <div id='configure-c' class='lang-configure'>
           </div>
           <div id='configure-markdown' class='lang-configure'>
+          </div>
+          <div id='configure-wasmtime-py' class='lang-configure'>
           </div>
           <div id='configure-rust' class='lang-configure'>
             &middot;

--- a/crates/witx-bindgen-demo/main.ts
+++ b/crates/witx-bindgen-demo/main.ts
@@ -168,6 +168,8 @@ class Editor {
       this.outputEditor.session.setMode("ace/mode/c_cpp");
     else if (this.files.value.endsWith('.md'))
       this.outputEditor.session.setMode("ace/mode/markdown");
+    else if (this.files.value.endsWith('.py'))
+      this.outputEditor.session.setMode("ace/mode/python");
     else
       this.outputEditor.session.setMode(null);
   }

--- a/crates/witx-bindgen-demo/main.ts
+++ b/crates/witx-bindgen-demo/main.ts
@@ -108,6 +108,7 @@ class Editor {
       case "js": lang = Lang.Js; break;
       case "rust": lang = Lang.Rust; break;
       case "wasmtime": lang = Lang.Wasmtime; break;
+      case "wasmtime-py": lang = Lang.WasmtimePy; break;
       case "c": lang = Lang.C; break;
       case "markdown": lang = Lang.Markdown; break;
       default: return;

--- a/crates/witx-bindgen-demo/src/lib.rs
+++ b/crates/witx-bindgen-demo/src/lib.rs
@@ -17,6 +17,7 @@ pub struct Config {
     c: RefCell<witx_bindgen_gen_c::Opts>,
     rust: RefCell<witx_bindgen_gen_rust_wasm::Opts>,
     wasmtime: RefCell<witx_bindgen_gen_wasmtime::Opts>,
+    wasmtime_py: RefCell<witx_bindgen_gen_wasmtime_py::Opts>,
     markdown: RefCell<witx_bindgen_gen_markdown::Opts>,
 }
 
@@ -43,6 +44,7 @@ impl demo::Config for Config {
         let mut gen: Box<dyn Generator> = match lang {
             demo::Lang::Rust => Box::new(self.rust.borrow().clone().build()),
             demo::Lang::Wasmtime => Box::new(self.wasmtime.borrow().clone().build()),
+            demo::Lang::WasmtimePy => Box::new(self.wasmtime_py.borrow().clone().build()),
             demo::Lang::Js => Box::new(self.js.borrow().clone().build()),
             demo::Lang::C => Box::new(self.c.borrow().clone().build()),
             demo::Lang::Markdown => Box::new(self.markdown.borrow().clone().build()),

--- a/src/bin/witx-bindgen.rs
+++ b/src/bin/witx-bindgen.rs
@@ -24,6 +24,12 @@ enum Command {
         #[structopt(flatten)]
         common: Common,
     },
+    WasmtimePy {
+        #[structopt(flatten)]
+        opts: witx_bindgen_gen_wasmtime_py::Opts,
+        #[structopt(flatten)]
+        common: Common,
+    },
     Js {
         #[structopt(flatten)]
         opts: witx_bindgen_gen_js::Opts,
@@ -67,6 +73,7 @@ fn main() -> Result<()> {
     let (mut generator, common): (Box<dyn Generator>, _) = match opt.command {
         Command::RustWasm { opts, common } => (Box::new(opts.build()), common),
         Command::Wasmtime { opts, common } => (Box::new(opts.build()), common),
+        Command::WasmtimePy { opts, common } => (Box::new(opts.build()), common),
         Command::Js { opts, common } => (Box::new(opts.build()), common),
         Command::C { opts, common } => (Box::new(opts.build()), common),
         Command::Markdown { opts, common } => (Box::new(opts.build()), common),

--- a/tests/host.witx
+++ b/tests/host.witx
@@ -112,6 +112,12 @@ list_result: function() -> list<u8>
 list_result2: function() -> string
 list_result3: function() -> list<string>
 
+list_minmax8: function(a: list<u8>, b: list<s8>) -> (list<u8>, list<s8>)
+list_minmax16: function(a: list<u16>, b: list<s16>) -> (list<u16>, list<s16>)
+list_minmax32: function(a: list<u32>, b: list<s32>) -> (list<u32>, list<s32>)
+list_minmax64: function(a: list<u64>, b: list<s64>) -> (list<u64>, list<s64>)
+list_minmax_float: function(a: list<f32>, b: list<f64>) -> (list<f32>, list<f64>)
+
 string_roundtrip: function(a: string) -> string
 
 unaligned_roundtrip1: function(a: list<u16>, b: list<u32>, c: list<u64>, d: list<flag32>, e: list<flag64>)


### PR DESCRIPTION
Currently supports everything necessary to run `host.witx`, but there
are known missing holes:

* Endianness isn't handled
* Probably not as efficient as it could be
* Legacy witx features aren't supported

This generator is intended for host embeddings of Python using the
`wasmtime` package on PyPI. This will generate Python with annotated
types for usage with `mypy` and other type checkers as well (and `mypy`
is a bit part of the tests for all of this). The idioms generated here
are a sort of blend of JS idioms where ownership doesn't matter and
Wasmtime idioms where types like the `Store` must be passed around. This
is intended to feel like idiomatic Python, but being someone who hasn't
written a lot of Python I'm sure there's room for improvement here and
there, so this is just a first pass.