### PR TITLE
Implement support for multiple exported interfaces in wasmlink.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,11 +117,9 @@ jobs:
       run: cargo install cargo-wasi
     - name: Build the markdown component
       run: cargo wasi build --release --manifest-path crates/wasmlink/demo/markdown/Cargo.toml
-    - name: Copy the witx file to target directory
-      run: cp crates/wasmlink/demo/markdown/markdown.witx crates/wasmlink/demo/markdown/target/wasm32-wasi/release/markdown.witx
     - name: Build the renderer component
       run: cargo wasi build --release --manifest-path crates/wasmlink/demo/renderer/Cargo.toml
     - name: Link the components
-      run: cargo run --release -p wasmlink-cli -- -i markdown=crates/wasmlink/demo/markdown/target/wasm32-wasi/release/markdown.wasm -p wasmtime -o linked.wasm crates/wasmlink/demo/renderer/target/wasm32-wasi/release/renderer.wasm
+      run: cargo run --release -p wasmlink-cli -- -m markdown=crates/wasmlink/demo/markdown/target/wasm32-wasi/release/markdown.wasm -i markdown=crates/wasmlink/demo/markdown/markdown.witx -p wasmtime -o linked.wasm crates/wasmlink/demo/renderer/target/wasm32-wasi/release/renderer.wasm
     - name: Run the linked component with Wasmtime
       run: printf '# Hello\nworld' | /tmp/wasmtime/wasmtime --enable-module-linking --enable-multi-memory linked.wasm | grep -q '<h1>Hello</h1>'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "wasmlink",
  "wasmtime",
  "wasmtime-wasi",
+ "witx2",
 ]
 
 [[package]]
@@ -1583,6 +1584,7 @@ dependencies = [
  "structopt",
  "wasmlink",
  "wat",
+ "witx2",
 ]
 
 [[package]]

--- a/crates/test-modules/Cargo.toml
+++ b/crates/test-modules/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.40"
 wasmlink = { path = "../wasmlink" }
+witx2 = { path = "../witx2" }
 
 [dev-dependencies]
 wasmtime = "0.28.0"

--- a/crates/wasmlink-cli/Cargo.toml
+++ b/crates/wasmlink-cli/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/bin/wasmlink.rs"
 
 [dependencies]
 wasmlink = { path = "../wasmlink" }
+witx2 = { path = "../witx2" }
 anyhow = "1.0.40"
 structopt = "0.3.21"
 log = "0.4.14"

--- a/crates/wasmlink/README.md
+++ b/crates/wasmlink/README.md
@@ -75,10 +75,7 @@ To build the `markdown` module:
 
 ```text
 $ cargo wasi build --manifest-path demo/markdown/Cargo.toml
-$ cp demo/markdown/markdown.witx demo/markdown/target/wasm32-wasi/debug/markdown.witx
 ```
-
-_Note: the linker currently expects either an embedded witx file in a custom section of the module or a witx file of the same name next to the input wasm module, so we copy the witx file to the target directory above._
 
 ### Building the `renderer` module
 
@@ -95,7 +92,7 @@ $ cargo wasi build --manifest-path demo/renderer/Cargo.toml
 With the two modules now built, it is time to link them together so that they can be run directly with [Wasmtime](https://github.com/bytecodealliance/wasmtime):
 
 ```text
-$ cargo run --release -p wasmlink-cli -- -i markdown=demo/markdown/target/wasm32-wasi/debug/markdown.wasm -p wasmtime -o linked.wasm demo/renderer/target/wasm32-wasi/debug/renderer.wasm
+$ cargo run --release -p wasmlink-cli -- -m markdown=demo/markdown/target/wasm32-wasi/debug/markdown.wasm -i markdown=demo/markdown/markdown.witx -p wasmtime -o linked.wasm demo/renderer/target/wasm32-wasi/debug/renderer.wasm
 ```
 
 This command produces a linked module named `linked.wasm` in the current directory.

--- a/crates/wasmlink/src/adapter/call.rs
+++ b/crates/wasmlink/src/adapter/call.rs
@@ -26,7 +26,7 @@ impl Locals {
     }
 
     fn allocate(&mut self) -> u32 {
-        assert!(self.allocated + 1 <= self.count);
+        assert!(self.allocated < self.count);
         let index = self.start + self.allocated;
         self.allocated += 1;
         index
@@ -222,6 +222,7 @@ pub(crate) struct CallAdapter<'a> {
 }
 
 impl<'a> CallAdapter<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         interface: &'a Interface,
         signature: &'a WasmSignature,
@@ -237,7 +238,7 @@ impl<'a> CallAdapter<'a> {
 
         let mut locals_count = 0;
 
-        let mut iter = (0..signature.params.len() as u32).into_iter();
+        let mut iter = 0..signature.params.len() as u32;
         let mut params = Vec::new();
         for (_, ty) in &func.params {
             Self::push_operands(
@@ -255,7 +256,7 @@ impl<'a> CallAdapter<'a> {
             // For the callee's retptr
             locals_count += 1;
 
-            let mut iter = (0..retptr.len() as u32).into_iter();
+            let mut iter = 0..retptr.len() as u32;
             let mut results = Vec::new();
             for (_, ty) in &func.results {
                 Self::push_operands(
@@ -274,7 +275,7 @@ impl<'a> CallAdapter<'a> {
             // Use the possible index for the return value local
             let index = signature.params.len() as u32 + locals_count;
 
-            let mut iter = (index..index + 1).into_iter();
+            let mut iter = index..index + 1;
             let mut results = Vec::new();
             Self::push_operands(
                 inner,
@@ -632,7 +633,7 @@ impl<'a> CallAdapter<'a> {
                     });
                 }
                 TypeDefKind::Record(r) => match r.kind {
-                    RecordKind::Flags(_) => return,
+                    RecordKind::Flags(_) => {}
                     RecordKind::Tuple | RecordKind::Other => {
                         let offsets = sizes.field_offsets(r);
 
@@ -649,7 +650,7 @@ impl<'a> CallAdapter<'a> {
                         }
                     }
                 },
-                TypeDefKind::Variant(v) if v.is_bool() || v.is_enum() => return,
+                TypeDefKind::Variant(v) if v.is_bool() || v.is_enum() => {}
                 TypeDefKind::Variant(v) => {
                     let payload_offset = sizes.payload_offset(v) as u32;
 
@@ -679,7 +680,7 @@ impl<'a> CallAdapter<'a> {
                         });
                     }
                 }
-                TypeDefKind::Pointer(_) | TypeDefKind::ConstPointer(_) => return,
+                TypeDefKind::Pointer(_) | TypeDefKind::ConstPointer(_) => {}
                 TypeDefKind::PushBuffer(_) | TypeDefKind::PullBuffer(_) => todo!(),
             },
             Type::Handle(id) => {
@@ -694,7 +695,7 @@ impl<'a> CallAdapter<'a> {
                     name: interface.resources[*id].name.as_str(),
                 });
             }
-            _ => return,
+            _ => {}
         }
     }
 
@@ -856,6 +857,7 @@ impl<'a> CallAdapter<'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn emit_copy_element_operands(
         &self,
         function: &mut wasm_encoder::Function,
@@ -920,6 +922,7 @@ impl<'a> CallAdapter<'a> {
         function.instruction(Instruction::End);
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn emit_copy_list(
         &self,
         function: &mut wasm_encoder::Function,

--- a/crates/wasmlink/src/profile.rs
+++ b/crates/wasmlink/src/profile.rs
@@ -3,7 +3,7 @@ use wasmparser::FuncType;
 /// Represents a link profile.
 ///
 /// Link profiles represent information about the target environment.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct Profile {}
 
 impl Profile {

--- a/crates/wasmlink/src/resources.rs
+++ b/crates/wasmlink/src/resources.rs
@@ -91,7 +91,7 @@ impl<'a> Resources<'a> {
         let mut remove_index = None;
         let mut drop_callback_type_index = None;
 
-        if module.has_resources() {
+        if module.has_resources {
             let mut type_map = HashMap::new();
 
             // Populate the types
@@ -139,7 +139,11 @@ impl<'a> Resources<'a> {
 
             drop_callback_type_index = Some(ft_pi32_index);
 
-            for (_, resource) in &module.interface.as_ref().unwrap().inner().resources {
+            for (_, resource) in module
+                .interfaces
+                .iter()
+                .flat_map(|i| i.inner().resources.iter())
+            {
                 if resource.foreign_module.is_some() {
                     continue;
                 }


### PR DESCRIPTION
Currently `wasmlink::Module` only supports reading an interface from a
custom section (unused) or from a path to a witx file.

In preparation for some upcoming work, this commit implements creating a
`wasmlink::Module` that exports more than one `witx2::Interface`.

`Module::new` now checks that given interfaces are not in conflict (e.g.
have a function/resource of the same name) and also verify that the
module actually does export those interfaces.

Also fixed some clippy lints in wasmlink.