### PR TITLE
Remove requirement that the module to link exports `_start`.

### DIFF
--- a/crates/wasmlink/src/linker.rs
+++ b/crates/wasmlink/src/linker.rs
@@ -37,6 +37,7 @@ struct LinkedModule<'a> {
     module_map: HashMap<&'a ModuleAdapter<'a>, (u32, Option<u32>)>,
     instances: Vec<(u32, Vec<(&'a str, u32)>)>,
     func_aliases: Vec<(u32, &'a str)>,
+    memory_aliases: Vec<(u32, &'a str)>,
     table_aliases: Vec<(u32, &'a str)>,
     segments: Vec<(u32, Vec<wasm_encoder::Element>)>,
     exports: Vec<(&'a str, wasm_encoder::Export)>,
@@ -131,15 +132,25 @@ impl<'a> LinkedModule<'a> {
 
         let root = &graph[NodeIndex::new(0)];
 
-        // Re-export all functions from the root module
+        // Re-export all supported exports from the root module
         for export in &root.module.exports {
-            if let ExternalKind::Function = export.kind {
-                let func_index = linked.func_aliases.len() as u32;
-                linked.func_aliases.push((root_index, export.field));
-                linked.exports.push((
-                    export.field,
-                    wasm_encoder::Export::Function(linked.imports.len() as u32 + func_index),
-                ));
+            match export.kind {
+                ExternalKind::Function => {
+                    let func_index = linked.func_aliases.len() as u32;
+                    linked.func_aliases.push((root_index, export.field));
+                    linked.exports.push((
+                        export.field,
+                        wasm_encoder::Export::Function(linked.imports.len() as u32 + func_index),
+                    ));
+                }
+                ExternalKind::Memory => {
+                    let memory_index = linked.memory_aliases.len() as u32;
+                    linked.memory_aliases.push((root_index, export.field));
+                    linked
+                        .exports
+                        .push((export.field, wasm_encoder::Export::Memory(memory_index)));
+                }
+                _ => {}
             }
         }
 
@@ -330,6 +341,10 @@ impl<'a> LinkedModule<'a> {
 
         for (index, name) in &self.table_aliases {
             section.instance_export(*index, wasm_encoder::ItemKind::Table, name);
+        }
+
+        for (index, name) in &self.memory_aliases {
+            section.instance_export(*index, wasm_encoder::ItemKind::Memory, name);
         }
 
         module.section(&section);
@@ -706,7 +721,7 @@ mod test {
     #[test]
     fn it_links_with_interface() -> Result<()> {
         let bytes = wat::parse_str(
-            r#"(module (import "a" "a" (func (param i32 i32))) (func (export "_start")) (func (export "canonical_abi_realloc") (param i32 i32 i32 i32) (result i32) unreachable))"#,
+            r#"(module (import "a" "a" (func (param i32 i32))) (func (export "_start")) (func (export "canonical_abi_realloc") (param i32 i32 i32 i32) (result i32) unreachable) (memory (export "memory") 0))"#,
         )?;
         let a = wat::parse_str(
             r#"(module (import "wasi_snapshot_preview1" "a" (func)) (func (export "a") (param i32 i32)) (memory (export "memory") 0) (func (export "canonical_abi_realloc") (param i32 i32 i32 i32) (result i32) unreachable) (func (export "canonical_abi_free") (param i32 i32 i32)))"#,
@@ -740,8 +755,10 @@ mod test {
     (func (;1;) (type 1))
     (func (;2;) (type 2) (param i32 i32 i32 i32) (result i32)
       unreachable)
+    (memory (;0;) 0)
     (export \"_start\" (func 1))
-    (export \"canonical_abi_realloc\" (func 2)))
+    (export \"canonical_abi_realloc\" (func 2))
+    (export \"memory\" (memory 0)))
   (module (;1;)
     (type (;0;) (func))
     (type (;1;) (func (param i32 i32)))
@@ -818,8 +835,10 @@ mod test {
   (alias 2 \"_start\" (func (;2;)))
   (alias 2 \"canonical_abi_realloc\" (func (;3;)))
   (alias 1 \"$funcs\" (table (;0;)))
+  (alias 2 \"memory\" (memory (;0;)))
   (export \"_start\" (func 2))
   (export \"canonical_abi_realloc\" (func 3))
+  (export \"memory\" (memory 0))
   (elem (;0;) (i32.const 0) funcref (ref.func 1)))"
         );
 

--- a/crates/wasmlink/src/linker.rs
+++ b/crates/wasmlink/src/linker.rs
@@ -126,16 +126,22 @@ impl<'a> LinkedModule<'a> {
             linked.instances.push((index, args));
         }
 
-        // Instantiate the main module
-        let (main_index, _) = linked.instantiate(graph, NodeIndex::new(0), None)?;
+        // Instantiate the root module
+        let (root_index, _) = linked.instantiate(graph, NodeIndex::new(0), None)?;
 
-        // Re-export the start function
-        let start_index = linked.func_aliases.len() as u32;
-        linked.func_aliases.push((main_index, "_start"));
-        linked.exports.push((
-            "_start",
-            wasm_encoder::Export::Function(linked.imports.len() as u32 + start_index),
-        ));
+        let root = &graph[NodeIndex::new(0)];
+
+        // Re-export all functions from the root module
+        for export in &root.module.exports {
+            if let ExternalKind::Function = export.kind {
+                let func_index = linked.func_aliases.len() as u32;
+                linked.func_aliases.push((root_index, export.field));
+                linked.exports.push((
+                    export.field,
+                    wasm_encoder::Export::Function(linked.imports.len() as u32 + func_index),
+                ));
+            }
+        }
 
         Ok(linked)
     }
@@ -370,21 +376,8 @@ impl Linker {
     /// Links the given module with the given set of imported modules.
     ///
     /// On success, returns a vector of bytes representing the linked module.
-    pub fn link(&self, main: &Module, imports: &HashMap<&str, Module>) -> Result<Vec<u8>> {
-        if !main.exports.iter().any(|e| match (e.field, e.kind) {
-            ("_start", ExternalKind::Function) => {
-                let ty = main.func_type(e.index).unwrap();
-                ty.params.is_empty() && ty.returns.is_empty()
-            }
-            _ => false,
-        }) {
-            bail!(
-                "main module `{}` must export a start function that has no parameters or results",
-                main.name
-            );
-        }
-
-        let (graph, needs_runtime) = self.build_graph(main, imports)?;
+    pub fn link(&self, module: &Module, imports: &HashMap<&str, Module>) -> Result<Vec<u8>> {
+        let (graph, needs_runtime) = self.build_graph(module, imports)?;
 
         let module = LinkedModule::new(&graph, needs_runtime, &self.profile)?;
 
@@ -393,16 +386,16 @@ impl Linker {
 
     fn build_graph<'a>(
         &self,
-        main: &'a Module,
+        module: &'a Module,
         imports: &'a HashMap<&str, Module>,
     ) -> Result<(Graph<ModuleAdapter<'a>, ()>, bool)> {
         let mut queue: Vec<(Option<petgraph::graph::NodeIndex>, &Module)> = Vec::new();
         let mut seen = HashMap::new();
         let mut graph: Graph<ModuleAdapter, ()> = Graph::new();
 
-        let mut needs_runtime = main.has_resources;
+        let mut needs_runtime = module.has_resources;
 
-        queue.push((None, main));
+        queue.push((None, module));
 
         let mut next_resource_id = 0;
 
@@ -475,36 +468,6 @@ impl Linker {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn it_errors_on_missing_main_function() -> Result<()> {
-        let bytes = wat::parse_str(r#"(module)"#)?;
-        let main = Module::new("main", &bytes, [])?;
-
-        let linker = Linker::new(Profile::new());
-
-        assert_eq!(
-            linker.link(&main, &HashMap::new()).unwrap_err().to_string(),
-            "main module `main` must export a start function that has no parameters or results"
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn it_errors_on_incorrect_main_function() -> Result<()> {
-        let bytes = wat::parse_str(r#"(module (func (export "_start") (param i32)))"#)?;
-        let main = Module::new("main", &bytes, [])?;
-
-        let linker = Linker::new(Profile::new());
-
-        assert_eq!(
-            linker.link(&main, &HashMap::new()).unwrap_err().to_string(),
-            "main module `main` must export a start function that has no parameters or results"
-        );
-
-        Ok(())
-    }
 
     #[test]
     fn it_errors_on_missing_import() -> Result<()> {
@@ -853,8 +816,10 @@ mod test {
       (import \"$parent\" (instance 2))))
   (alias 3 \"a\" (func (;1;)))
   (alias 2 \"_start\" (func (;2;)))
+  (alias 2 \"canonical_abi_realloc\" (func (;3;)))
   (alias 1 \"$funcs\" (table (;0;)))
   (export \"_start\" (func 2))
+  (export \"canonical_abi_realloc\" (func 3))
   (elem (;0;) (i32.const 0) funcref (ref.func 1)))"
         );
 


### PR DESCRIPTION
This PR removes the requirement that the root module being linked
exports a `_start` function.

Instead, it now simply reexports all exported functions.  This will
enable use of the linked modules from profiles where a start function
isn't necessary (i.e. the host will call some other function).

Updated the CLI to remove references to a "main" module.

Fixes #59.