### PR TITLE
Make generated export Wasmtime bindings module public

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -363,7 +363,7 @@ impl Generator for Wasmtime {
         self.in_import = dir == Direction::Import;
         self.trait_name = iface.name.to_camel_case();
         self.src
-            .push_str(&format!("mod {} {{\n", iface.name.to_snake_case()));
+            .push_str(&format!("pub mod {} {{\n", iface.name.to_snake_case()));
         self.src
             .push_str("#[allow(unused_imports)]\nuse witx_bindgen_wasmtime::{wasmtime, anyhow};\n");
         self.sizes.fill(dir, iface);


### PR DESCRIPTION
This commit updates the Wasmtime export bindings module's visibility to public.
This makes it very convenient to directly use the generated module in a crate.

Signed-off-by: Radu M <root@radu.sh>