### PR TITLE
Add #ifdef to C headers so they can be directly reused in CPP files

### DIFF
--- a/crates/gen-c/src/lib.rs
+++ b/crates/gen-c/src/lib.rs
@@ -1056,6 +1056,11 @@ impl Generator for C {
     fn finish(&mut self, iface: &Interface, files: &mut Files) {
         self.src.h(&format!(
             "\
+                #ifdef __cplusplus
+                extern \"C\"
+                {{
+                #endif
+
                 #ifndef __BINDINGS_{0}_H
                 #define __BINDINGS_{0}_H
 
@@ -1243,6 +1248,11 @@ impl Generator for C {
             }
         }
 
+        self.src.h("\
+        #ifdef __cplusplus
+        }
+        #endif
+        ");
         self.src.h("#endif\n");
 
         files.push(&format!("{}.c", iface.name), self.src.src.as_bytes());

--- a/crates/gen-c/src/lib.rs
+++ b/crates/gen-c/src/lib.rs
@@ -1056,13 +1056,12 @@ impl Generator for C {
     fn finish(&mut self, iface: &Interface, files: &mut Files) {
         self.src.h(&format!(
             "\
+                #ifndef __BINDINGS_{0}_H
+                #define __BINDINGS_{0}_H
                 #ifdef __cplusplus
                 extern \"C\"
                 {{
                 #endif
-
-                #ifndef __BINDINGS_{0}_H
-                #define __BINDINGS_{0}_H
 
                 #include <stdint.h>
                 #include <stdbool.h>


### PR DESCRIPTION
This commit enables the C bindings to be imported directly by a C++ source file.

(Note that the C implementation will still have to be separately compiled with the C compiler.)

Signed-off-by: Radu M <root@radu.sh>