### PR TITLE
wasmtime: Fix overlapping trait impls on tuples

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -427,6 +427,7 @@ impl Generator for Wasmtime {
         // is usable.
         if self.modes_of(iface, id).len() > 0
             && record.fields.iter().all(|f| iface.all_bits_valid(&f.ty))
+            && !record.is_tuple()
         {
             self.src.push_str("impl witx_bindgen_wasmtime::Endian for ");
             self.src.push_str(&name.to_camel_case());

--- a/tests/records.witx
+++ b/tests/records.witx
@@ -39,3 +39,8 @@ record aggregates {
 
 aggregate_arg: function(x: aggregates)
 aggregate_result: function() -> aggregates
+
+type tuple_typedef = tuple<s32>
+type int_typedef = s32
+type tuple_typedef2 = tuple<int_typedef>
+typedef_inout: function(e: tuple_typedef2) -> s32


### PR DESCRIPTION
No need to synthesize trait trait implementations for tuples since
they're already baked into the runtime library.

Closes #63