### PR TITLE
Improve spidermonkey.wasm's error message for importing nonexistent m…

### DIFF
--- a/crates/gen-spidermonkey/spidermonkey-wasm/initialize.cpp
+++ b/crates/gen-spidermonkey/spidermonkey-wasm/initialize.cpp
@@ -121,6 +121,13 @@ JSObject* module_resolve_hook(JSContext *cx,
         }
     }
 
+
+    JS::UniqueChars utf8 = JS_EncodeStringToUTF8(cx, specifier);
+    if (!utf8) {
+        JS_ReportErrorASCII(cx, "failed to find module import");
+        return nullptr;
+    }
+    JS_ReportErrorASCII(cx, "failed to find module import: `%s`", utf8.get());
     return nullptr;
 }
 


### PR DESCRIPTION
…odules

Previously the error message was actually nonexistent, simply saying
that module instantiation failed, but now there's an error message
indicating which imported-from module doesn't exist.