### PR TITLE
Add initial support for `async` functions in witx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+
+[[package]]
+name = "futures-util"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +973,18 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1230,6 +1290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1415,7 @@ dependencies = [
 name = "test-rust-wasm"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "witx-bindgen-rust",
 ]
 
@@ -2071,6 +2138,7 @@ dependencies = [
 name = "witx-bindgen-rust"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "witx-bindgen-rust-impl",
 ]
 

--- a/crates/gen-c/src/lib.rs
+++ b/crates/gen-c/src/lib.rs
@@ -921,6 +921,7 @@ impl Generator for C {
     }
 
     fn import(&mut self, iface: &Interface, func: &Function) {
+        assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
         let sig = iface.wasm_signature(Direction::Import, func);
 
@@ -994,6 +995,7 @@ impl Generator for C {
     }
 
     fn export(&mut self, iface: &Interface, func: &Function) {
+        assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
         let sig = iface.wasm_signature(Direction::Export, func);
 

--- a/crates/gen-c/tests/codegen.rs
+++ b/crates/gen-c/tests/codegen.rs
@@ -6,12 +6,18 @@ mod imports {
     test_helpers::codegen_c_import!(
         // ...
         "*.witx"
+
+        // TODO: implement async support
+        "!async_functions.witx"
     );
 }
 
 mod exports {
     test_helpers::codegen_c_export!(
         "*.witx"
+
+        // TODO: implement async support
+        "!async_functions.witx"
 
         // These use preview1 ABI things which are only supported for imports
         "!wasi_snapshot_preview1.witx"

--- a/crates/gen-js/tests/codegen.rs
+++ b/crates/gen-js/tests/codegen.rs
@@ -22,7 +22,7 @@ mod exports {
     );
 }
 
-fn verify(dir: &str, _name: &str) {
+fn verify(dir: &str, name: &str) {
     let (cmd, args) = if cfg!(windows) {
         ("cmd.exe", &["/c", "npx.cmd"] as &[&str])
     } else {
@@ -34,7 +34,7 @@ fn verify(dir: &str, _name: &str) {
         .arg("eslint")
         .arg("-c")
         .arg(".eslintrc.js")
-        .arg(Path::new(dir).join("bindings.js"))
+        .arg(Path::new(dir).join(&format!("{}.js", name)))
         .status()
         .unwrap();
     assert!(status.success());

--- a/crates/gen-js/tests/runtime.rs
+++ b/crates/gen-js/tests/runtime.rs
@@ -11,27 +11,17 @@ fn execute(name: &str, wasm: &Path, ts: &Path, imports: &Path, exports: &Path) {
     dir.push(name);
     drop(fs::remove_dir_all(&dir));
     fs::create_dir_all(&dir).unwrap();
-    fs::create_dir_all(&dir.join("imports")).unwrap();
-    fs::create_dir_all(&dir.join("exports")).unwrap();
 
     println!("OUT_DIR = {:?}", dir);
     println!("Generating bindings...");
     let imports = witx_bindgen_gen_core::witx2::Interface::parse_file(imports).unwrap();
     let exports = witx_bindgen_gen_core::witx2::Interface::parse_file(exports).unwrap();
-    // TODO: should combine these calls into one
-    let mut import_files = Default::default();
-    let mut export_files = Default::default();
+    let mut files = Default::default();
     witx_bindgen_gen_js::Opts::default()
         .build()
-        .generate_all(&[imports], &[], &mut import_files);
-    witx_bindgen_gen_js::Opts::default()
-        .build()
-        .generate_all(&[], &[exports], &mut export_files);
-    for (file, contents) in import_files.iter() {
-        fs::write(dir.join("imports").join(file), contents).unwrap();
-    }
-    for (file, contents) in export_files.iter() {
-        fs::write(dir.join("exports").join(file), contents).unwrap();
+        .generate_all(&[imports], &[exports], &mut files);
+    for (file, contents) in files.iter() {
+        fs::write(dir.join(file), contents).unwrap();
     }
 
     let (cmd, args) = if cfg!(windows) {

--- a/crates/gen-spidermonkey/src/lib.rs
+++ b/crates/gen-spidermonkey/src/lib.rs
@@ -997,6 +997,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
     }
 
     fn import(&mut self, iface: &witx2::Interface, func: &witx2::Function) {
+        assert!(!func.is_async, "async not supported yet");
         assert!(
             func.abi == witx2::abi::Abi::Canonical,
             "We only support the canonical ABI right now"
@@ -1039,6 +1040,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
     }
 
     fn export(&mut self, iface: &witx2::Interface, func: &witx2::Function) {
+        assert!(!func.is_async, "async not supported yet");
         assert!(
             func.abi == witx2::abi::Abi::Canonical,
             "We only support the canonical ABI right now"
@@ -2040,6 +2042,10 @@ impl witx2::abi::Bindgen for Bindgen<'_, '_> {
                 self.inst(Instruction::Call(self.gen.spidermonkey_import("SMW_call")));
                 // []
             }
+
+            witx2::abi::Instruction::CallWasmAsyncExport { .. } => todo!(),
+            witx2::abi::Instruction::CallWasmAsyncImport { .. } => todo!(),
+
             witx2::abi::Instruction::Return { amt, func: _ } => {
                 match self.lift_lower {
                     witx2::abi::LiftLower::LowerArgsLiftResults => {
@@ -2104,6 +2110,10 @@ impl witx2::abi::Bindgen for Bindgen<'_, '_> {
                     }
                 }
             }
+
+            witx2::abi::Instruction::ReturnAsyncExport { .. } => todo!(),
+            witx2::abi::Instruction::ReturnAsyncImport { .. } => todo!(),
+
             witx2::abi::Instruction::Witx { instr: _ } => {
                 unreachable!("we do not support the preview1 ABI")
             }

--- a/crates/gen-wasmtime-py/src/lib.rs
+++ b/crates/gen-wasmtime-py/src/lib.rs
@@ -831,6 +831,7 @@ impl Generator for WasmtimePy {
     }
 
     fn import(&mut self, iface: &Interface, func: &Function) {
+        assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
 
         self.print_sig(iface, func);
@@ -944,6 +945,7 @@ impl Generator for WasmtimePy {
     }
 
     fn export(&mut self, iface: &Interface, func: &Function) {
+        assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
 
         let params = self.print_sig(iface, func);

--- a/crates/gen-wasmtime-py/tests/codegen.rs
+++ b/crates/gen-wasmtime-py/tests/codegen.rs
@@ -5,6 +5,9 @@ mod imports {
     test_helpers::codegen_py_import!(
         "*.witx"
 
+        // TODO: implement async support
+        "!async_functions.witx"
+
         // The python generator doesn't support the legacy witx features at this
         // time.
         "!legacy.witx"
@@ -15,6 +18,9 @@ mod imports {
 mod exports {
     test_helpers::codegen_py_export!(
         "*.witx"
+
+        // TODO: implement async support
+        "!async_functions.witx"
 
         // This uses buffers, which we don't support in exports just yet
         // TODO: should support this

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -569,6 +569,7 @@ impl Generator for Wasmtime {
     // }
 
     fn import(&mut self, iface: &Interface, func: &Function) {
+        assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
 
         let is_dtor = self.types.is_preview1_dtor_func(func);
@@ -750,6 +751,7 @@ impl Generator for Wasmtime {
     }
 
     fn export(&mut self, iface: &Interface, func: &Function) {
+        assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
 
         // If anything is asynchronous on exports then everything must be
@@ -2094,6 +2096,9 @@ impl Bindgen for FunctionBindgen<'_> {
                 self.caller_memory_available = false; // invalidated by call
             }
 
+            Instruction::CallWasmAsyncImport { .. } => unimplemented!(),
+            Instruction::CallWasmAsyncExport { .. } => unimplemented!(),
+
             Instruction::CallInterface { module: _, func } => {
                 for (i, operand) in operands.iter().enumerate() {
                     self.push_str(&format!("let param{} = {};\n", i, operand));
@@ -2187,6 +2192,9 @@ impl Bindgen for FunctionBindgen<'_> {
                     None => self.push_str(&result),
                 }
             }
+
+            Instruction::ReturnAsyncExport { .. } => unimplemented!(),
+            Instruction::ReturnAsyncImport { .. } => unimplemented!(),
 
             Instruction::I32Load { offset } => results.push(self.load(*offset, "i32", operands)),
             Instruction::I32Load8U { offset } => {

--- a/crates/gen-wasmtime/tests/codegen.rs
+++ b/crates/gen-wasmtime/tests/codegen.rs
@@ -9,6 +9,9 @@ mod imports {
     test_helpers::codegen_wasmtime_import!(
         "*.witx"
 
+        // TODO: implement async support
+        "!async_functions.witx"
+
         // If you want to exclude a specific test you can include it here with
         // gitignore glob syntax:
         //
@@ -24,6 +27,9 @@ mod imports {
 mod exports {
     test_helpers::codegen_wasmtime_export!(
         "*.witx"
+
+        // TODO: implement async support
+        "!async_functions.witx"
 
         // TODO: these use push/pull buffer which isn't implemented in the test
         // generator just yet

--- a/crates/rust-wasm/Cargo.toml
+++ b/crates/rust-wasm/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 witx-bindgen-rust-impl = { path = "../rust-wasm-impl" }
+async-trait = "0.1.51"
 
 [features]
 old-witx-compat = ['witx-bindgen-rust-impl/old-witx-compat']

--- a/crates/rust-wasm/src/futures.rs
+++ b/crates/rust-wasm/src/futures.rs
@@ -1,0 +1,202 @@
+//! Helper library support for `async` witx functions, used for both
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::mem;
+use std::pin::Pin;
+use std::rc::{Rc, Weak};
+use std::sync::Arc;
+use std::task::*;
+
+#[link(wasm_import_module = "canonical_abi")]
+extern "C" {
+    pub fn async_export_done(ctx: i32, ptr: i32);
+}
+
+struct PollingWaker {
+    state: RefCell<State>,
+}
+
+enum State {
+    Waiting(Pin<Box<dyn Future<Output = ()>>>),
+    Polling,
+    Woken,
+}
+
+// These are valid for single-threaded WebAssembly because everything is
+// single-threaded and send/sync don't matter much. This module will need
+// an alternative implementation for threaded WebAssembly when that comes about
+// to host runtimes off-the-web.
+#[cfg(not(target_feature = "atomics"))]
+unsafe impl Send for PollingWaker {}
+#[cfg(not(target_feature = "atomics"))]
+unsafe impl Sync for PollingWaker {}
+
+/// Runs the `future` provided to completion, polling the future whenever its
+/// waker receives a call to `wake`.
+pub fn execute(future: impl Future<Output = ()> + 'static) {
+    let waker = Arc::new(PollingWaker {
+        state: RefCell::new(State::Waiting(Box::pin(future))),
+    });
+    waker.wake()
+}
+
+impl Wake for PollingWaker {
+    fn wake(self: Arc<Self>) {
+        let mut state = self.state.borrow_mut();
+        let mut future = match mem::replace(&mut *state, State::Polling) {
+            // We are the first wake to come in to wake-up this future. This
+            // means that we need to actually poll the future, so leave the
+            // `Polling` state in place.
+            State::Waiting(future) => future,
+
+            // Otherwise the future is either already polling or it was already
+            // woken while it was being polled, in both instances we reset the
+            // state back to `Woken` and then we return. This means that the
+            // future is owned by some previous stack frame and will drive the
+            // future as necessary.
+            State::Polling | State::Woken => {
+                *state = State::Woken;
+                return;
+            }
+        };
+        drop(state);
+
+        // Create the futures waker/context from ourselves, used for polling.
+        let waker = self.clone().into();
+        let mut cx = Context::from_waker(&waker);
+        loop {
+            match future.as_mut().poll(&mut cx) {
+                // The future is finished! By returning here we destroy the
+                // future and release all of its resources.
+                Poll::Ready(()) => break,
+
+                // The future has work yet-to-do, so continue below.
+                Poll::Pending => {}
+            }
+
+            let mut state = self.state.borrow_mut();
+            match *state {
+                // This means that we were not woken while we were polling and
+                // the state is as it was when we took out the future before. By
+                // `Pending` being returned at this point we're guaranteed that
+                // our waker will be woken up at some point in the future, which
+                // will come look at this future again. This means that we
+                // simply store our future and return, since this call to `wake`
+                // is now finished.
+                State::Polling => {
+                    *state = State::Waiting(future);
+                    break;
+                }
+
+                // This means that we received a call to `wake` while we were
+                // polling. Ideally we'd enqueue some sort of microtask-tick
+                // here or something like that but for now we just loop around
+                // and poll again.
+                State::Woken => {}
+
+                // This shouldn't be possible since we own the future, and no
+                // one else should insert another future here.
+                State::Waiting(_) => unreachable!(),
+            }
+        }
+    }
+}
+
+pub struct Oneshot<T> {
+    inner: Weak<OneshotInner<T>>,
+}
+
+pub struct Sender<T> {
+    inner: Rc<OneshotInner<T>>,
+}
+
+struct OneshotInner<T> {
+    state: RefCell<OneshotState<T>>,
+}
+
+enum OneshotState<T> {
+    Start,
+    Waiting(Waker),
+    Done(T),
+}
+
+impl<T> Oneshot<T> {
+    /// Returns a new "oneshot" channel as well as a completion callback.
+    pub fn new() -> (Oneshot<T>, Sender<T>) {
+        let inner = Rc::new(OneshotInner {
+            state: RefCell::new(OneshotState::Start),
+        });
+        (
+            Oneshot {
+                inner: Rc::downgrade(&inner),
+            },
+            Sender { inner },
+        )
+    }
+}
+
+impl<T> Future for Oneshot<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        let inner = match self.inner.upgrade() {
+            Some(inner) => inner,
+            // Technically this isn't possible in the initial draft of interface
+            // types unless there's some serious bug somewhere.
+            None => panic!("completion callback was canceled"),
+        };
+        let mut state = inner.state.borrow_mut();
+        match mem::replace(&mut *state, OneshotState::Start) {
+            OneshotState::Done(t) => Poll::Ready(t),
+            OneshotState::Waiting(_) | OneshotState::Start => {
+                *state = OneshotState::Waiting(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}
+
+impl<T> Sender<T> {
+    pub fn into_usize(self) -> usize {
+        Rc::into_raw(self.inner) as usize
+    }
+
+    pub unsafe fn from_usize(ptr: usize) -> Sender<T> {
+        Sender {
+            inner: Rc::from_raw(ptr as *const _),
+        }
+    }
+
+    pub fn send(self, val: T) {
+        let mut state = self.inner.state.borrow_mut();
+        let prev = mem::replace(&mut *state, OneshotState::Done(val));
+        // Must `drop` before the `wake` below because waking may induce
+        // polling which would induce another `borrow_mut` which would
+        // conflict with this `borrow_mut` otherwise.
+        drop(state);
+
+        match prev {
+            // nothing has polled the returned future just yet, so we just
+            // filled in the result of the computation. Presumably this will
+            // get picked up at some point in the future.
+            OneshotState::Start => {}
+
+            // Something was waiting for the result, so we wake the waker
+            // here which, for wasm, will likely induce polling immediately.
+            OneshotState::Waiting(waker) => waker.wake(),
+
+            // Shouldn't be possible, this is the only closure that writes
+            // `Done` and this can only be invoked once.
+            OneshotState::Done(_) => unreachable!(),
+        }
+    }
+}
+
+impl<T> Drop for OneshotInner<T> {
+    fn drop(&mut self) {
+        if let OneshotState::Waiting(waker) = &*self.state.borrow() {
+            waker.wake_by_ref();
+        }
+    }
+}

--- a/crates/rust-wasm/src/futures.rs
+++ b/crates/rust-wasm/src/futures.rs
@@ -8,9 +8,15 @@ use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::task::*;
 
+#[cfg(target_arch = "wasm32")]
 #[link(wasm_import_module = "canonical_abi")]
 extern "C" {
     pub fn async_export_done(ctx: i32, ptr: i32);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub unsafe extern "C" fn async_export_done(_ctx: i32, _ptr: i32) {
+    panic!("only supported on wasm");
 }
 
 struct PollingWaker {

--- a/crates/rust-wasm/src/lib.rs
+++ b/crates/rust-wasm/src/lib.rs
@@ -1,3 +1,4 @@
+pub use async_trait::async_trait;
 use std::fmt;
 use std::marker;
 use std::mem;
@@ -5,6 +6,7 @@ use std::ops::Deref;
 pub use witx_bindgen_rust_impl::{export, import};
 
 pub mod exports;
+mod futures;
 pub mod imports;
 
 /// A type for handles to resources that appear in exported functions.
@@ -121,6 +123,8 @@ pub unsafe trait LocalHandle: HandleType {
 #[doc(hidden)]
 pub mod rt {
     use std::alloc::{self, Layout};
+
+    pub use crate::futures::*;
 
     #[no_mangle]
     unsafe extern "C" fn canonical_abi_realloc(

--- a/crates/test-helpers/build.rs
+++ b/crates/test-helpers/build.rs
@@ -15,7 +15,9 @@ fn main() {
             .current_dir("../test-rust-wasm")
             .arg("--target=wasm32-wasi")
             .env("CARGO_TARGET_DIR", &out_dir)
-            .env("CARGO_PROFILE_DEV_DEBUG", "1");
+            .env("CARGO_PROFILE_DEV_DEBUG", "1")
+            .env("RUSTFLAGS", "-Clink-args=--export-table")
+            .env_remove("CARGO_ENCODED_RUSTFLAGS");
         let status = cmd.status().unwrap();
         assert!(status.success());
         for file in out_dir.join("wasm32-wasi/debug").read_dir().unwrap() {

--- a/crates/test-modules/modules/Cargo.lock
+++ b/crates/test-modules/modules/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
+name = "async-trait"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "flags"
 version = "0.1.0"
 dependencies = [
@@ -212,6 +223,7 @@ dependencies = [
 name = "witx-bindgen-rust"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "witx-bindgen-rust-impl",
 ]
 

--- a/crates/test-rust-wasm/Cargo.toml
+++ b/crates/test-rust-wasm/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+futures-util = { version = "0.3.17", default-features = true }
 witx-bindgen-rust = { path = "../rust-wasm", features = ['old-witx-compat'] }
 
 [features]
@@ -45,4 +46,8 @@ test = false
 
 [[bin]]
 name = "invalid"
+test = false
+
+[[bin]]
+name = "async_functions"
 test = false

--- a/crates/test-rust-wasm/src/bin/async_functions.rs
+++ b/crates/test-rust-wasm/src/bin/async_functions.rs
@@ -1,0 +1,3 @@
+include!("../../../../tests/runtime/async_functions/wasm.rs");
+
+fn main() {}

--- a/crates/witx-bindgen-demo/build.sh
+++ b/crates/witx-bindgen-demo/build.sh
@@ -8,8 +8,10 @@ mkdir static
 cargo build -p witx-bindgen-demo --target wasm32-unknown-unknown --release
 cp target/wasm32-unknown-unknown/release/witx_bindgen_demo.wasm static/demo.wasm
 
-cargo run -- js --import crates/witx-bindgen-demo/browser.witx --out-dir static/browser
-cargo run -- js --export crates/witx-bindgen-demo/demo.witx --out-dir static/demo
+cargo run js \
+  --import crates/witx-bindgen-demo/browser.witx \
+  --export crates/witx-bindgen-demo/demo.witx \
+  --out-dir static
 
 cp crates/witx-bindgen-demo/{index.html,main.ts} static/
 (cd crates/witx-bindgen-demo && npx tsc ../../static/main.ts --target es6)

--- a/crates/witx-bindgen-demo/demo.witx
+++ b/crates/witx-bindgen-demo/demo.witx
@@ -1,6 +1,6 @@
 type files = list<tuple<string, string>>
 
-variant async {
+variant wasmtime_async {
   all,
   none,
   only(list<string>),
@@ -23,6 +23,6 @@ resource config {
 
   set_rust_unchecked: function(unchecked: bool)
   set_wasmtime_tracing: function(unchecked: bool)
-  set_wasmtime_async: function(async: async)
+  set_wasmtime_async: function(val: wasmtime_async)
   set_wasmtime_custom_error: function(custom: bool)
 }

--- a/crates/witx-bindgen-demo/main.ts
+++ b/crates/witx-bindgen-demo/main.ts
@@ -1,5 +1,5 @@
-import { Demo, Lang, Config } from './demo/bindings.js';
-import * as browser from './browser/bindings.js';
+import { Demo, Lang, Config } from './demo.js';
+import * as browser from './browser.js';
 
 class Editor {
   input: HTMLTextAreaElement;

--- a/crates/witx-bindgen-demo/src/lib.rs
+++ b/crates/witx-bindgen-demo/src/lib.rs
@@ -72,13 +72,13 @@ impl demo::Config for Config {
         browser::log("custom error");
         self.wasmtime.borrow_mut().custom_error = custom_error;
     }
-    fn set_wasmtime_async(&self, async_: demo::Async) {
+    fn set_wasmtime_async(&self, async_: demo::WasmtimeAsync) {
         use witx_bindgen_gen_wasmtime::Async;
 
         self.wasmtime.borrow_mut().async_ = match async_ {
-            demo::Async::All => Async::All,
-            demo::Async::None => Async::None,
-            demo::Async::Only(list) => Async::Only(list.into_iter().collect()),
+            demo::WasmtimeAsync::All => Async::All,
+            demo::WasmtimeAsync::None => Async::None,
+            demo::WasmtimeAsync::Only(list) => Async::Only(list.into_iter().collect()),
         };
     }
 }

--- a/crates/witx2/src/ast/lex.rs
+++ b/crates/witx2/src/ast/lex.rs
@@ -77,6 +77,7 @@ pub enum Token {
     Static,
     Interface,
     Tuple,
+    Async,
 
     Id,
     StrLit,
@@ -246,6 +247,7 @@ impl<'a> Tokenizer<'a> {
                     "static" => Static,
                     "interface" => Interface,
                     "tuple" => Tuple,
+                    "async" => Async,
                     _ => Id,
                 }
             }
@@ -430,6 +432,7 @@ impl Token {
             Static => "keyword `static`",
             Interface => "keyword `interface`",
             Tuple => "keyword `tuple`",
+            Async => "keyword `async`",
         }
     }
 }

--- a/crates/witx2/src/ast/resolve.rs
+++ b/crates/witx2/src/ast/resolve.rs
@@ -527,6 +527,7 @@ impl Resolver {
         let docs = self.docs(&value.docs);
         match &value.kind {
             ValueKind::Function {
+                is_async,
                 abi,
                 params,
                 results,
@@ -546,6 +547,7 @@ impl Resolver {
                     kind: FunctionKind::Freestanding,
                     params,
                     results,
+                    is_async: *is_async,
                 });
             }
             ValueKind::Global(ty) => {
@@ -564,12 +566,13 @@ impl Resolver {
         let mut names = HashSet::new();
         let id = self.resource_lookup[&*resource.name.name];
         for (statik, value) in resource.values.iter() {
-            let (abi, params, results) = match &value.kind {
+            let (abi, is_async, params, results) = match &value.kind {
                 ValueKind::Function {
                     abi,
+                    is_async,
                     params,
                     results,
-                } => (*abi, params, results),
+                } => (*abi, *is_async, params, results),
                 ValueKind::Global(_) => {
                     return Err(Error {
                         span: value.name.span,
@@ -608,6 +611,7 @@ impl Resolver {
             };
             self.functions.push(Function {
                 abi,
+                is_async,
                 docs,
                 name: format!("{}::{}", resource.name.name, value.name.name),
                 kind,

--- a/crates/witx2/src/lib.rs
+++ b/crates/witx2/src/lib.rs
@@ -234,6 +234,7 @@ pub struct Global {
 #[derive(Debug)]
 pub struct Function {
     pub abi: abi::Abi,
+    pub is_async: bool,
     pub docs: Docs,
     pub name: String,
     pub kind: FunctionKind,

--- a/crates/witx2/tests/all.rs
+++ b/crates/witx2/tests/all.rs
@@ -202,6 +202,8 @@ fn to_json(i: &witx2::Interface) -> String {
     #[derive(Serialize)]
     struct Function {
         name: String,
+        #[serde(rename = "async", skip_serializing_if = "Option::is_none")]
+        is_async: Option<bool>,
         params: Vec<String>,
         results: Vec<String>,
     }
@@ -236,6 +238,7 @@ fn to_json(i: &witx2::Interface) -> String {
         .iter()
         .map(|f| Function {
             name: f.name.clone(),
+            is_async: if f.is_async { Some(f.is_async) } else { None },
             params: f.params.iter().map(|(_, ty)| translate_type(ty)).collect(),
             results: f.results.iter().map(|(_, ty)| translate_type(ty)).collect(),
         })

--- a/crates/witx2/tests/ui/async.witx
+++ b/crates/witx2/tests/ui/async.witx
@@ -1,0 +1,9 @@
+a: async function()
+b: async function(x: s32)
+c: async function() -> u32
+
+resource y {
+  a: async function()
+  b: async function(x: s32)
+  c: async function() -> u32
+}

--- a/crates/witx2/tests/ui/async.witx.result
+++ b/crates/witx2/tests/ui/async.witx.result
@@ -1,0 +1,64 @@
+{
+  "resources": [
+    {
+      "name": "y"
+    }
+  ],
+  "types": [
+    {
+      "idx": 0,
+      "primitive": "handle-0"
+    }
+  ],
+  "functions": [
+    {
+      "name": "a",
+      "async": true,
+      "params": [],
+      "results": []
+    },
+    {
+      "name": "b",
+      "async": true,
+      "params": [
+        "s32"
+      ],
+      "results": []
+    },
+    {
+      "name": "c",
+      "async": true,
+      "params": [],
+      "results": [
+        "u32"
+      ]
+    },
+    {
+      "name": "y::a",
+      "async": true,
+      "params": [
+        "handle-0"
+      ],
+      "results": []
+    },
+    {
+      "name": "y::b",
+      "async": true,
+      "params": [
+        "handle-0",
+        "s32"
+      ],
+      "results": []
+    },
+    {
+      "name": "y::c",
+      "async": true,
+      "params": [
+        "handle-0"
+      ],
+      "results": [
+        "u32"
+      ]
+    }
+  ]
+}

--- a/crates/witx2/tests/ui/parse-fail/async.witx
+++ b/crates/witx2/tests/ui/parse-fail/async.witx
@@ -1,0 +1,2 @@
+// parse-fail
+a: async

--- a/crates/witx2/tests/ui/parse-fail/async.witx.result
+++ b/crates/witx2/tests/ui/parse-fail/async.witx.result
@@ -1,0 +1,5 @@
+expected keyword `function`, found eof
+     --> tests/ui/parse-fail/async.witx:3:1
+      |
+    3 | 
+      | ^

--- a/crates/witx2/tests/ui/parse-fail/async1.witx
+++ b/crates/witx2/tests/ui/parse-fail/async1.witx
@@ -1,0 +1,3 @@
+// parse-fail
+a: async()
+

--- a/crates/witx2/tests/ui/parse-fail/async1.witx.result
+++ b/crates/witx2/tests/ui/parse-fail/async1.witx.result
@@ -1,0 +1,5 @@
+expected keyword `function`, found '('
+     --> tests/ui/parse-fail/async1.witx:2:9
+      |
+    2 | a: async()
+      |         ^

--- a/tests/codegen/async_functions.witx
+++ b/tests/codegen/async_functions.witx
@@ -1,0 +1,7 @@
+async_no_args: async function()
+async_args: async function(a: u32, b: string, c: list<string>)
+async_results: async function() -> (u32, string, list<string>)
+
+resource async_resource {
+  frob: async function()
+}

--- a/tests/runtime/async_functions/exports.witx
+++ b/tests/runtime/async_functions/exports.witx
@@ -1,0 +1,4 @@
+thunk: async function()
+allocated_bytes: function() -> u32
+
+test_concurrent: async function()

--- a/tests/runtime/async_functions/host.ts
+++ b/tests/runtime/async_functions/host.ts
@@ -1,0 +1,106 @@
+import { addImportsToImports, Imports } from "./imports.js";
+import { Exports } from "./exports.js";
+import { getWasm, addWasiToImports } from "./helpers.js";
+// @ts-ignore
+import * as assert from 'assert';
+
+function promiseChannel(): [Promise<void>, () => void] {
+  let resolveCallback = null;
+  const promise = new Promise((resolve, reject) => resolveCallback = resolve);
+  // @ts-ignore
+  return [promise, resolveCallback];
+}
+
+async function run() {
+  const importObj = {};
+  let hit = false;
+
+  const [concurrentPromise, resolveConcurrent] = promiseChannel();
+  const [unblockConcurrent1, resolveUnblockConcurrent1] = promiseChannel();
+  const [unblockConcurrent2, resolveUnblockConcurrent2] = promiseChannel();
+  const [unblockConcurrent3, resolveUnblockConcurrent3] = promiseChannel();
+
+  const imports: Imports = {
+    async thunk() {
+      if (hit) {
+        console.log('second time in thunk, throwing an error');
+        throw new Error('catch me');
+      } else {
+        console.log('first time in thunk');
+        await some_helper();
+        console.log('waited on the helper, returning from host thunk');
+        hit = true;
+      }
+    },
+
+    async concurrent1(val) {
+      console.log('wasm called concurrent1');
+      assert.equal(val, 1);
+      resolveUnblockConcurrent1();
+      console.log('concurrent1 to reenter back into the host');
+      await concurrentPromise;
+      console.log('concurrent1 returning to wasm');
+      return 11;
+    },
+    async concurrent2(val) {
+      console.log('wasm called concurrent2');
+      assert.equal(val, 2);
+      resolveUnblockConcurrent2();
+      console.log('concurrent2 to reenter back into the host');
+      await concurrentPromise;
+      console.log('concurrent2 returning to wasm');
+      return 12;
+    },
+    async concurrent3(val) {
+      console.log('wasm called concurrent3');
+      assert.equal(val, 3);
+      resolveUnblockConcurrent3();
+      console.log('concurrent3 to reenter back into the host');
+      await concurrentPromise;
+      console.log('concurrent3 returning to wasm');
+      return 13;
+    },
+  };
+  let instance: WebAssembly.Instance;
+  addImportsToImports(importObj, imports, name => instance.exports[name]);
+  const wasi = addWasiToImports(importObj);
+
+  const wasm = new Exports();
+  await wasm.instantiate(getWasm(), importObj);
+  wasi.start(wasm.instance);
+  instance = wasm.instance;
+
+  const initBytes = wasm.allocatedBytes();
+  console.log("calling initial async function");
+  await wasm.thunk();
+  assert.ok(hit, "import not called");
+  assert.equal(initBytes, wasm.allocatedBytes());
+
+  // Make sure that exceptions on the host make their way back to whomever's
+  // doing the actual `await`
+  try {
+    console.log('executing thunk export a second time');
+    await wasm.thunk();
+    throw new Error('expected an error to get thrown');
+  } catch (e) {
+    const err = e as Error;
+    console.log('caught error with', err.message);
+    assert.equal(err.message, 'catch me');
+  }
+
+  console.log('entering wasm');
+  const concurrentWasm = wasm.testConcurrent();
+  console.log('waiting for wasm to enter the host');
+  await unblockConcurrent1;
+  await unblockConcurrent2;
+  await unblockConcurrent3;
+  console.log('allowing host functions to finish');
+  resolveConcurrent();
+  console.log('waiting on host functions');
+  await concurrentWasm;
+  console.log('concurrent wasm finished');
+}
+
+async function some_helper() {}
+
+await run()

--- a/tests/runtime/async_functions/imports.witx
+++ b/tests/runtime/async_functions/imports.witx
@@ -1,0 +1,5 @@
+thunk: async function()
+
+concurrent1: async function(a: u32) -> u32
+concurrent2: async function(a: u32) -> u32
+concurrent3: async function(a: u32) -> u32

--- a/tests/runtime/async_functions/wasm.rs
+++ b/tests/runtime/async_functions/wasm.rs
@@ -1,0 +1,23 @@
+witx_bindgen_rust::import!("./tests/runtime/async_functions/imports.witx");
+witx_bindgen_rust::export!("./tests/runtime/async_functions/exports.witx");
+
+struct Exports;
+
+#[witx_bindgen_rust::async_trait(?Send)]
+impl exports::Exports for Exports {
+    fn allocated_bytes() -> u32 {
+        test_rust_wasm::get() as u32
+    }
+
+    async fn thunk() {
+        imports::thunk().await;
+    }
+
+    async fn test_concurrent() {
+        let a1 = imports::concurrent1(1);
+        let a2 = imports::concurrent2(2);
+        let a3 = imports::concurrent3(3);
+
+        assert_eq!(futures_util::join!(a2, a3, a1), (12, 13, 11));
+    }
+}

--- a/tests/runtime/buffers/host.ts
+++ b/tests/runtime/buffers/host.ts
@@ -1,6 +1,5 @@
-import { addImportsToImports, Imports } from "./imports/bindings.js";
-import { Exports } from "./exports/bindings.js";
-import * as exports from "./exports/bindings.js";
+import { addImportsToImports, Imports } from "./imports.js";
+import { Exports } from "./exports.js";
 import { getWasm, addWasiToImports } from "./helpers.js";
 // @ts-ignore
 import * as assert from 'assert';

--- a/tests/runtime/flavorful/host.ts
+++ b/tests/runtime/flavorful/host.ts
@@ -1,6 +1,6 @@
-import { addImportsToImports, Imports, MyErrno } from "./imports/bindings.js";
-import { Exports } from "./exports/bindings.js";
-import * as exports from "./exports/bindings.js";
+import { addImportsToImports, Imports, MyErrno } from "./imports.js";
+import { Exports } from "./exports.js";
+import * as exports from "./exports.js";
 import { getWasm, addWasiToImports } from "./helpers.js";
 // @ts-ignore
 import * as assert from 'assert';

--- a/tests/runtime/handles/host.ts
+++ b/tests/runtime/handles/host.ts
@@ -1,6 +1,6 @@
-import { addImportsToImports, Imports } from "./imports/bindings.js";
-import { Exports } from "./exports/bindings.js";
-import * as exports from "./exports/bindings.js";
+import { addImportsToImports, Imports } from "./imports.js";
+import { Exports } from "./exports.js";
+import * as exports from "./exports.js";
 import { getWasm, addWasiToImports } from "./helpers.js";
 // @ts-ignore
 import * as assert from 'assert';

--- a/tests/runtime/invalid/host.ts
+++ b/tests/runtime/invalid/host.ts
@@ -1,6 +1,5 @@
-import { addImportsToImports, Imports } from "./imports/bindings.js";
-import { Exports } from "./exports/bindings.js";
-import * as exports from "./exports/bindings.js";
+import { addImportsToImports, Imports } from "./imports.js";
+import { Exports } from "./exports.js";
 import { getWasm, addWasiToImports } from "./helpers.js";
 // @ts-ignore
 import * as assert from 'assert';

--- a/tests/runtime/js_instantiate/host.ts
+++ b/tests/runtime/js_instantiate/host.ts
@@ -1,4 +1,4 @@
-import { Exports } from "./exports/bindings.js";
+import { Exports } from "./exports.js";
 import { getWasm } from "./helpers.js";
 
 async function run() {

--- a/tests/runtime/lists/host.ts
+++ b/tests/runtime/lists/host.ts
@@ -1,6 +1,6 @@
-import { addImportsToImports, Imports, FLAG32_B8, FLAG64_B9 } from "./imports/bindings.js";
-import { Exports } from "./exports/bindings.js";
-import * as exports from "./exports/bindings.js";
+import { addImportsToImports, Imports, FLAG32_B8, FLAG64_B9 } from "./imports.js";
+import { Exports } from "./exports.js";
+import * as exports from "./exports.js";
 import { getWasm, addWasiToImports } from "./helpers.js";
 // @ts-ignore
 import * as assert from 'assert';

--- a/tests/runtime/numbers/host.ts
+++ b/tests/runtime/numbers/host.ts
@@ -1,5 +1,5 @@
-import { addImportsToImports, Imports } from "./imports/bindings.js";
-import { Exports } from "./exports/bindings.js";
+import { addImportsToImports, Imports } from "./imports.js";
+import { Exports } from "./exports.js";
 import { getWasm, addWasiToImports } from "./helpers.js";
 
 function assertEq(x: any, y: any) {

--- a/tests/runtime/records/host.ts
+++ b/tests/runtime/records/host.ts
@@ -1,6 +1,6 @@
-import { addImportsToImports, Imports } from "./imports/bindings.js";
-import { Exports } from "./exports/bindings.js";
-import * as exports from "./exports/bindings.js";
+import { addImportsToImports, Imports } from "./imports.js";
+import { Exports } from "./exports.js";
+import * as exports from "./exports.js";
 import { getWasm, addWasiToImports } from "./helpers.js";
 // @ts-ignore
 import * as assert from 'assert';

--- a/tests/runtime/smoke/host.ts
+++ b/tests/runtime/smoke/host.ts
@@ -1,5 +1,5 @@
-import { addImportsToImports, Imports } from "./imports/bindings.js";
-import { Exports } from "./exports/bindings.js";
+import { addImportsToImports, Imports } from "./imports.js";
+import { Exports } from "./exports.js";
 import { getWasm, addWasiToImports } from "./helpers.js";
 
 function assert(x: boolean, msg: string) {

--- a/tests/runtime/variants/host.ts
+++ b/tests/runtime/variants/host.ts
@@ -1,6 +1,6 @@
-import { addImportsToImports, Imports, MyErrno } from "./imports/bindings.js";
-import { Exports } from "./exports/bindings.js";
-import * as exports from "./exports/bindings.js";
+import { addImportsToImports, Imports, MyErrno } from "./imports.js";
+import { Exports } from "./exports.js";
+import * as exports from "./exports.js";
 import { getWasm, addWasiToImports } from "./helpers.js";
 // @ts-ignore
 import * as assert from 'assert';


### PR DESCRIPTION
This commit is the initial steps towards supporting and implementing
`async` function as-specified in `*.witx` itself. The goal of this is to
implement the callback-based ABI of async functions and streams as
presented in WASI subgroup meetings.

This commit itself only implements async functions for the
compiled-to-Rust guest and a JS host. The next PR is to implement async
functions for a Wasmtime host, followed by an implementation of streams
afterwards.

Included here is:

* Updates to the `*.witx` syntax and parsing.
* Assertions in code generators that don't support async that async
  isn't used.
* An implementation of the callback ABI for `async` functions for
  compiled-to-wasm Rust modules. This includes a simple "executor" to
  track the state of async imports/exports. Everything is only exposed
  with `async` functions in Rust, no callbacks are part of the interface
  of the generated bindings.
* An implementation of the callback ABI for JS hosts. This is
  exposed with `async` functions and only uses callbacks under-the-hood.

This change had some significant ramifications on the generated bindings
for JS hosts. Namely both imports and exports needed to access the same
state of callbacks so they are no longer generated separately in
isolation but rather together in the same manner as the spidermonkey
bindings. I expect that most generators will migrate to this pattern in
the future. Work was done internally to deduplicate intrinsics across
bindings modules, namely the promise-related intrinsics.

The testing so far isn't super strenuous, but a major thing I made sure
to implement is that when an asynchronous wasm function is called and
later some asynchronous import throws an exception that should carry the
exception to the original wasm export's promise in JS. This is intended
to map to basically what `async` and `await` feel like in JS normally.
Otherwise though there's codegen tests for flavorful types being used
in parameters/results for async functions (and this test is ignored in
most generators at the moment) and runtime tests for some concurrency.