### PR TITLE
Fix names defining resource intrinsics in Wasmtime

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -990,20 +990,21 @@ impl Generator for Wasmtime {
                     self.src.push_str(&format!(
                         "linker.func_wrap(
                             \"canonical_abi\",
-                            \"resource_drop_{}\",
+                            \"resource_drop_{name}\",
                             move |mut caller: wasmtime::Caller<'_, T>, handle: u32| {{
                                 let (host, tables) = get(caller.data_mut());
                                 let handle = tables
-                                    .{0}_table
+                                    .{snake}_table
                                     .remove(handle)
                                     .map_err(|e| {{
                                         wasmtime::Trap::new(format!(\"failed to remove handle: {{}}\", e))
                                     }})?;
-                                host.drop_{0}(handle);
+                                host.drop_{snake}(handle);
                                 Ok(())
                             }}
                         )?;\n",
-                        handle.to_snake_case(),
+                        name = handle,
+                        snake = handle.to_snake_case(),
                     ));
                 }
             }

--- a/tests/runtime/handles/host.py
+++ b/tests/runtime/handles/host.py
@@ -40,6 +40,12 @@ class Markdown(i.Markdown2):
     def render(self) -> str:
         return self.buf.replace('red', 'green')
 
+
+class OddName(i.OddName):
+    def frob_the_odd(self) -> None:
+        pass
+
+
 class MyImports:
     def host_state_create(self) -> i.HostState:
         return HostState(100)
@@ -95,6 +101,9 @@ class MyImports:
 
     def markdown2_create(self) -> i.Markdown2:
         return Markdown()
+
+    def odd_name_create(self) -> i.OddName:
+        return OddName()
 
 def run(wasm_file: str) -> None:
     store = wasmtime.Store()

--- a/tests/runtime/handles/host.rs
+++ b/tests/runtime/handles/host.rs
@@ -21,6 +21,7 @@ impl Imports for MyImports {
     type HostState = SuchState;
     type HostState2 = ();
     type Markdown2 = Markdown;
+    type OddName = ();
 
     fn host_state_create(&mut self) -> SuchState {
         SuchState(100)
@@ -81,6 +82,9 @@ impl Imports for MyImports {
     fn markdown2_render(&mut self, md: &Markdown) -> String {
         md.buf.borrow().replace("red", "green")
     }
+
+    fn odd_name_create(&mut self) {}
+    fn odd_name_frob_the_odd(&mut self, _: &()) {}
 }
 
 witx_bindgen_wasmtime::export!("./tests/runtime/handles/exports.witx");

--- a/tests/runtime/handles/host.ts
+++ b/tests/runtime/handles/host.ts
@@ -46,6 +46,13 @@ async function run() {
 
       return new Markdown();
     },
+
+    oddNameCreate() {
+      class OddName {
+        frobTheOdd() {}
+      }
+      return new OddName();
+    }
   };
   let instance: WebAssembly.Instance;
   addImportsToImports(importObj, imports, name => instance.exports[name]);

--- a/tests/runtime/handles/imports.witx
+++ b/tests/runtime/handles/imports.witx
@@ -49,3 +49,7 @@ resource markdown2 {
   render: function() -> string
 }
 
+resource "Odd name" {
+  static create: function() -> "Odd name"
+  "frob the odd": function()
+}

--- a/tests/runtime/handles/wasm.rs
+++ b/tests/runtime/handles/wasm.rs
@@ -50,6 +50,9 @@ impl exports::Exports for Exports {
         let md = Markdown2::create();
         md.append("red is the best color");
         assert_eq!(md.render(), "green is the best color");
+
+        let odd = OddName::create();
+        odd.frob_the_odd();
     }
 
     fn wasm_state_create() -> Handle<WasmState> {


### PR DESCRIPTION
There was an accidentaly `.to_snake_case()` when it should have been
using the raw name from the witx.

Closes #76