### PR TITLE
Revert "Swap `import` and `export` in the Wasmtime bindings."

### DIFF
--- a/crates/gen-c/tests/codegen.rs
+++ b/crates/gen-c/tests/codegen.rs
@@ -26,11 +26,6 @@ mod exports {
         // yet
         "!wasi_next.witx"
         "!host.witx"
-
-        // These use the preview1 ABI which isn't implemented for C exports.
-        "!wasi_snapshot_preview1.witx"
-        "!typenames.witx"
-        "!legacy.witx"
     );
 }
 

--- a/crates/gen-js/tests/codegen.rs
+++ b/crates/gen-js/tests/codegen.rs
@@ -19,11 +19,6 @@ mod exports {
         // TODO: should support this
         "!wasi_next.witx"
         "!host.witx"
-
-        // These use the preview1 ABI which isn't implemented for JS exports.
-        "!wasi_snapshot_preview1.witx"
-        "!typenames.witx"
-        "!legacy.witx"
     );
 }
 

--- a/crates/gen-rust-wasm/tests/codegen.rs
+++ b/crates/gen-rust-wasm/tests/codegen.rs
@@ -28,10 +28,5 @@ mod exports {
         // generator just yet
         "!wasi_next.witx"
         "!host.witx"
-
-        // These use the preview1 ABI which isn't implemented for rust_wasm exports.
-        "!wasi_snapshot_preview1.witx"
-        "!typenames.witx"
-        "!legacy.witx"
     );
 }

--- a/crates/gen-wasmtime-py/tests/codegen.rs
+++ b/crates/gen-wasmtime-py/tests/codegen.rs
@@ -26,11 +26,6 @@ mod exports {
         // TODO: should support this
         "!wasi_next.witx"
         "!host.witx"
-
-        // These use the preview1 ABI which isn't implemented for C exports.
-        "!wasi_snapshot_preview1.witx"
-        "!typenames.witx"
-        "!legacy.witx"
     );
 }
 

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -321,7 +321,7 @@ impl RustGenerator for Wasmtime {
                 self.push_str(" mut ");
             }
             self.push_str(&format!(
-                "witx_bindgen_wasmtime::exports::{}Buffer<{}, ",
+                "witx_bindgen_wasmtime::imports::{}Buffer<{}, ",
                 if push { "Push" } else { "Pull" },
                 lt,
             ));
@@ -359,10 +359,6 @@ impl RustGenerator for Wasmtime {
 
 impl Generator for Wasmtime {
     fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
-        let dir = match dir {
-            Direction::Export => Direction::Import,
-            Direction::Import => Direction::Export,
-        };
         self.types.analyze(iface);
         self.in_import = dir == Direction::Import;
         self.trait_name = iface.name.to_camel_case();
@@ -572,7 +568,7 @@ impl Generator for Wasmtime {
     //     ));
     // }
 
-    fn export(&mut self, iface: &Interface, func: &Function) {
+    fn import(&mut self, iface: &Interface, func: &Function) {
         assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
 
@@ -754,7 +750,7 @@ impl Generator for Wasmtime {
             });
     }
 
-    fn import(&mut self, iface: &Interface, func: &Function) {
+    fn export(&mut self, iface: &Interface, func: &Function) {
         assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
 
@@ -1060,7 +1056,7 @@ impl Generator for Wasmtime {
                 self.push_str(",\n");
             }
             // if self.needs_buffer_glue {
-            //     self.push_str("buffer_glue: witx_bindgen_wasmtime::imports::BufferGlue,");
+            //     self.push_str("buffer_glue: witx_bindgen_wasmtime::exports::BufferGlue,");
             // }
             self.push_str("}\n");
             let bound = if self.opts.async_.is_none() {
@@ -1160,7 +1156,7 @@ impl Generator for Wasmtime {
             //         "
             //             use witx_bindgen_wasmtime::rt::get_memory;
 
-            //             let buffer_glue = witx_bindgen_wasmtime::imports::BufferGlue::default();
+            //             let buffer_glue = witx_bindgen_wasmtime::exports::BufferGlue::default();
             //             let g = buffer_glue.clone();
             //             linker.func(
             //                 \"witx_canonical_buffer_abi\",
@@ -2004,7 +2000,7 @@ impl Bindgen for FunctionBindgen<'_> {
                         self.closures.push_str(&block);
                         self.closures.push_str("; Ok(()) };\n");
                         results.push(format!(
-                            "witx_bindgen_wasmtime::exports::PushBuffer::new(
+                            "witx_bindgen_wasmtime::imports::PushBuffer::new(
                                 &mut _bc, ptr{}, len{}, {}, &{})?",
                             tmp, tmp, size, closure
                         ));
@@ -2013,7 +2009,7 @@ impl Bindgen for FunctionBindgen<'_> {
                         self.closures.push_str(&block);
                         self.closures.push_str(") };\n");
                         results.push(format!(
-                            "witx_bindgen_wasmtime::exports::PullBuffer::new(
+                            "witx_bindgen_wasmtime::imports::PullBuffer::new(
                                 &mut _bc, ptr{}, len{}, {}, &{})?",
                             tmp, tmp, size, closure
                         ));

--- a/crates/gen-wasmtime/tests/codegen.rs
+++ b/crates/gen-wasmtime/tests/codegen.rs
@@ -5,8 +5,8 @@ fn main() {
 }
 
 #[rustfmt::skip]
-mod exports {
-    test_helpers::codegen_wasmtime_export!(
+mod imports {
+    test_helpers::codegen_wasmtime_import!(
         "*.witx"
 
         // TODO: implement async support
@@ -24,8 +24,8 @@ mod exports {
     );
 }
 
-mod imports {
-    test_helpers::codegen_wasmtime_import!(
+mod exports {
+    test_helpers::codegen_wasmtime_export!(
         "*.witx"
 
         // TODO: implement async support
@@ -35,17 +35,12 @@ mod imports {
         // generator just yet
         "!wasi_next.witx"
         "!host.witx"
-
-        // These use the preview1 ABI which isn't implemented for wasmtime imports.
-        "!wasi_snapshot_preview1.witx"
-        "!typenames.witx"
-        "!legacy.witx"
     );
 }
 
 mod async_tests {
     mod not_async {
-        witx_bindgen_wasmtime::export!({
+        witx_bindgen_wasmtime::import!({
             src["x"]: "foo: function()",
             async: ["bar"],
         });
@@ -57,7 +52,7 @@ mod async_tests {
         }
     }
     mod one_async {
-        witx_bindgen_wasmtime::export!({
+        witx_bindgen_wasmtime::import!({
             src["x"]: "
                 foo: function() -> list<u8>
                 bar: function()
@@ -77,7 +72,7 @@ mod async_tests {
         }
     }
     mod one_async_export {
-        witx_bindgen_wasmtime::import!({
+        witx_bindgen_wasmtime::export!({
             src["x"]: "
                 foo: function(x: list<string>)
                 bar: function()
@@ -86,7 +81,7 @@ mod async_tests {
         });
     }
     mod resource_with_none_async {
-        witx_bindgen_wasmtime::export!({
+        witx_bindgen_wasmtime::import!({
             src["x"]: "
                 resource y {
                     z: function() -> string
@@ -98,7 +93,7 @@ mod async_tests {
 }
 
 mod custom_errors {
-    witx_bindgen_wasmtime::export!({
+    witx_bindgen_wasmtime::import!({
         src["x"]: "
             foo: function()
             bar: function() -> expected<_, u32>

--- a/crates/test-helpers/src/lib.rs
+++ b/crates/test-helpers/src/lib.rs
@@ -4,18 +4,8 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
+use witx_bindgen_gen_core::witx2::abi::Direction;
 use witx_bindgen_gen_core::Generator;
-
-/// This is the direction from the user's perspective. Are we importing
-/// functions to call, or defining functions and exporting them to be called?
-///
-/// This differs from the `witx2::abi::Direction` value in some bindings; see
-/// the comments on the `Direction` enum in wasmtime-impl for details.
-#[derive(PartialEq, Eq, Copy, Clone)]
-enum Direction {
-    Import,
-    Export,
-}
 
 #[proc_macro]
 #[cfg(feature = "witx-bindgen-gen-rust-wasm")]
@@ -238,18 +228,18 @@ pub fn codegen_rust_wasm_export(input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 #[cfg(feature = "witx-bindgen-gen-wasmtime")]
-pub fn codegen_wasmtime_export(input: TokenStream) -> TokenStream {
+pub fn codegen_wasmtime_import(input: TokenStream) -> TokenStream {
     gen_rust(
         input,
-        Direction::Export,
+        Direction::Import,
         &[
             (
-                "export",
+                "import",
                 || witx_bindgen_gen_wasmtime::Opts::default().build(),
                 |_| quote::quote!(),
             ),
             (
-                "export-tracing-and-custom-error",
+                "import-tracing-and-custom-error",
                 || {
                     let mut opts = witx_bindgen_gen_wasmtime::Opts::default();
                     opts.tracing = true;
@@ -259,7 +249,7 @@ pub fn codegen_wasmtime_export(input: TokenStream) -> TokenStream {
                 |_| quote::quote!(),
             ),
             (
-                "export-async",
+                "import-async",
                 || {
                     let mut opts = witx_bindgen_gen_wasmtime::Opts::default();
                     opts.async_ = witx_bindgen_gen_wasmtime::Async::All;
@@ -273,18 +263,18 @@ pub fn codegen_wasmtime_export(input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 #[cfg(feature = "witx-bindgen-gen-wasmtime")]
-pub fn codegen_wasmtime_import(input: TokenStream) -> TokenStream {
+pub fn codegen_wasmtime_export(input: TokenStream) -> TokenStream {
     gen_rust(
         input,
-        Direction::Import,
+        Direction::Export,
         &[
             (
-                "import",
+                "export",
                 || witx_bindgen_gen_wasmtime::Opts::default().build(),
                 |_| quote::quote!(),
             ),
             (
-                "import-async",
+                "export-async",
                 || {
                     let mut opts = witx_bindgen_gen_wasmtime::Opts::default();
                     opts.async_ = witx_bindgen_gen_wasmtime::Async::All;
@@ -407,6 +397,12 @@ where
     let cwd = env::current_dir().unwrap();
     for test in tests {
         let (mut gen, dir) = mkgen(&test);
+        if dir == Direction::Export {
+            match test.file_name().unwrap().to_str().unwrap() {
+                "wasi_snapshot_preview1.witx" | "typenames.witx" | "legacy.witx" => continue,
+                _ => {}
+            }
+        }
         let mut files = Default::default();
         let iface = witx2::Interface::parse_file(&test).unwrap();
         let (mut imports, mut exports) = match dir {

--- a/crates/wasmtime-impl/src/lib.rs
+++ b/crates/wasmtime-impl/src/lib.rs
@@ -2,43 +2,15 @@ use proc_macro::TokenStream;
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{token, Token};
+use witx2::abi::Direction;
 use witx_bindgen_gen_core::{witx2, Files, Generator};
 use witx_bindgen_gen_wasmtime::Async;
 
-/// This is the direction from the user's perspective. Are we importing
-/// functions to call, or defining functions and exporting them to be called?
-///
-/// In the wasmtime bindings, this is the opposite of the witx2::abi::Direction
-/// value, because these bindings work differently from other bindings:
-///
-/// In a wasm-calling-wasm use case, one wasm module would use the `Import`
-/// ABI, the other would use the `Export` ABI, and there would be an adapter
-/// layer between the two that translates from one ABI to the other.
-///
-/// With wasm-calling-host, we don't go through a separate adapter layer;
-/// the binding code we generate on the host side just does everything
-/// itself. So when the host is conceptually "exporting" a function to
-/// wasm, it uses the `Import` ABI so that wasm can also use the `Import`
-/// ABI and import it directly from the host.
-///
-/// These are all implementation details; from the user perspective, it's
-/// just: `export` means I'm exporting functions to be called, `import`
-/// means I'm importing functions that I'm going to call, in both wasm
-/// modules and host code. The enum here represents this user perspective.
-enum Direction {
-    Import,
-    Export,
-}
-
-/// Generate code to support consuming the given interfaces, importaing them
-/// from wasm modules.
 #[proc_macro]
 pub fn import(input: TokenStream) -> TokenStream {
     run(input, Direction::Import)
 }
 
-/// Generate code to support implementing the given interfaces and exporting
-/// them to wasm modules.
 #[proc_macro]
 pub fn export(input: TokenStream) -> TokenStream {
     run(input, Direction::Export)

--- a/crates/wasmtime/src/exports.rs
+++ b/crates/wasmtime/src/exports.rs
@@ -1,90 +1,415 @@
-use crate::BorrowChecker;
-use std::fmt;
+use crate::slab::Slab;
+use std::cell::RefCell;
+use std::convert::TryFrom;
 use std::mem;
-use wasmtime::Trap;
+use std::rc::Rc;
+use wasmtime::{Memory, Trap};
 
-pub struct PullBuffer<'a, T> {
-    mem: &'a [u8],
-    size: usize,
-    deserialize: &'a (dyn Fn(&'a [u8]) -> Result<T, Trap> + Send + Sync + 'a),
+#[derive(Default, Clone)]
+pub struct BufferGlue {
+    inner: Rc<RefCell<Inner>>,
 }
 
-impl<'a, T> PullBuffer<'a, T> {
-    pub fn new(
-        mem: &mut BorrowChecker<'a>,
-        offset: i32,
-        len: i32,
-        size: i32,
-        deserialize: &'a (dyn Fn(&'a [u8]) -> Result<T, Trap> + Send + Sync + 'a),
-    ) -> Result<PullBuffer<'a, T>, Trap> {
-        Ok(PullBuffer {
-            mem: mem.slice(offset, len.saturating_mul(size))?,
-            size: size as usize,
-            deserialize,
-        })
-    }
-
-    pub fn len(&self) -> usize {
-        self.mem.len() / self.size
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = Result<T, Trap>> + 'a {
-        let deserialize = self.deserialize;
-        self.mem.chunks(self.size).map(deserialize)
-    }
+#[derive(Default)]
+struct Inner {
+    in_buffers: Slab<Buffer<Input>>,
+    out_buffers: Slab<Buffer<Output>>,
 }
 
-impl<T> fmt::Debug for PullBuffer<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PullBuffer")
-            .field("len", &self.len())
-            .finish()
-    }
+struct Buffer<T> {
+    len: u32,
+    kind: T,
 }
 
-pub struct PushBuffer<'a, T> {
-    mem: &'a mut [u8],
-    size: usize,
-    serialize: &'a (dyn Fn(&mut [u8], T) -> Result<(), Trap> + Send + Sync + 'a),
+enum Input {
+    Bytes(*const u8, usize),
+    General {
+        shim: unsafe fn([usize; 2], *const u8, &Memory, i32, u32, &mut u32) -> Result<(), Trap>,
+        iterator: [usize; 2],
+        serialize: *const u8,
+    },
 }
 
-impl<'a, T> PushBuffer<'a, T> {
-    pub fn new(
-        mem: &mut BorrowChecker<'a>,
-        offset: i32,
-        len: i32,
-        size: i32,
-        serialize: &'a (dyn Fn(&mut [u8], T) -> Result<(), Trap> + Send + Sync + 'a),
-    ) -> Result<PushBuffer<'a, T>, Trap> {
-        let mem = mem.slice_mut(offset, (len as u32).saturating_mul(size as u32) as i32)?;
-        Ok(PushBuffer {
-            mem,
-            size: size as usize,
-            serialize,
-        })
-    }
+enum Output {
+    Bytes(*mut u8, usize),
+    General {
+        shim: unsafe fn(*mut u8, *const u8, &Memory, i32, u32) -> Result<(), Trap>,
+        dst: *mut u8,
+        deserialize: *const u8,
+    },
+}
 
-    pub fn capacity(&self) -> usize {
-        self.mem.len() / self.size
-    }
-
-    pub fn write(&mut self, iter: impl IntoIterator<Item = T>) -> Result<(), Trap> {
-        for item in iter {
-            if self.mem.len() == 0 {
-                return Err(Trap::new("too many results in `PushBuffer::write`"));
-            }
-            let (chunk, rest) = mem::take(&mut self.mem).split_at_mut(self.size);
-            self.mem = rest;
-            (self.serialize)(chunk, item)?;
+impl BufferGlue {
+    pub fn transaction(&self) -> BufferTransaction<'_> {
+        BufferTransaction {
+            handles: Vec::new(),
+            glue: self,
         }
-        Ok(())
+    }
+
+    pub fn in_len(&self, handle: u32) -> Result<u32, Trap> {
+        let mut inner = self.inner.borrow_mut();
+        let b = inner
+            .in_buffers
+            .get_mut(handle)
+            .ok_or_else(|| Trap::new("invalid in-buffer handle"))?;
+        Ok(b.len)
+    }
+
+    /// Implementation of the canonical abi "in_read" function
+    pub fn in_read(
+        &self,
+        handle: u32,
+        store: impl wasmtime::AsContextMut,
+        memory: &wasmtime::Memory,
+        base: u32,
+        len: u32,
+    ) -> Result<(), Trap> {
+        let mut inner = self.inner.borrow_mut();
+        let b = inner
+            .in_buffers
+            .get_mut(handle)
+            .ok_or_else(|| Trap::new("invalid in-buffer handle"))?;
+        if len > b.len {
+            return Err(Trap::new(
+                "more items requested from in-buffer than are available",
+            ));
+        }
+        unsafe {
+            match &mut b.kind {
+                Input::Bytes(ptr, elem_size) => {
+                    let write_size = (len as usize) * *elem_size;
+                    memory
+                        .write(
+                            store,
+                            base as usize,
+                            std::slice::from_raw_parts(*ptr, write_size),
+                        )
+                        .map_err(|_| Trap::new("out-of-bounds write while reading in-buffer"))?;
+                    *ptr = (*ptr).add(write_size);
+                    b.len -= len;
+                    Ok(())
+                }
+                &mut Input::General {
+                    shim,
+                    iterator,
+                    serialize,
+                } => {
+                    drop(inner);
+                    let mut processed = 0;
+                    let res = shim(
+                        iterator,
+                        serialize,
+                        memory,
+                        base as i32,
+                        len,
+                        &mut processed,
+                    );
+                    self.inner
+                        .borrow_mut()
+                        .in_buffers
+                        .get_mut(handle)
+                        .expect("should still be there")
+                        .len -= processed;
+                    res
+                }
+            }
+        }
+    }
+
+    pub fn out_len(&self, handle: u32) -> Result<u32, Trap> {
+        let mut inner = self.inner.borrow_mut();
+        let b = inner
+            .out_buffers
+            .get_mut(handle)
+            .ok_or_else(|| Trap::new("out in-buffer handle"))?;
+        Ok(b.len)
+    }
+
+    /// Implementation of the canonical abi "out_write" function
+    pub fn out_write(
+        &self,
+        handle: u32,
+        store: impl wasmtime::AsContext,
+        memory: &wasmtime::Memory,
+        base: u32,
+        len: u32,
+    ) -> Result<(), Trap> {
+        let mut inner = self.inner.borrow_mut();
+        let b = inner
+            .out_buffers
+            .get_mut(handle)
+            .ok_or_else(|| Trap::new("invalid out-buffer handle"))?;
+        if len > b.len {
+            return Err(Trap::new(
+                "more items written to out-buffer than are available",
+            ));
+        }
+        unsafe {
+            match &mut b.kind {
+                Output::Bytes(ptr, elem_size) => {
+                    let read_size = (len as usize) * *elem_size;
+                    memory
+                        .read(
+                            &store,
+                            base as usize,
+                            std::slice::from_raw_parts_mut(*ptr, read_size),
+                        )
+                        .map_err(|_| Trap::new("out-of-bounds read while writing to out-buffer"))?;
+                    *ptr = (*ptr).add(read_size);
+                    b.len -= len;
+                    Ok(())
+                }
+                &mut Output::General {
+                    shim,
+                    dst,
+                    deserialize,
+                } => {
+                    shim(dst, deserialize, memory, base as i32, len)?;
+                    b.len -= len;
+                    Ok(())
+                }
+            }
+        }
     }
 }
 
-impl<T> fmt::Debug for PushBuffer<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PushBuffer")
-            .field("capacity", &self.capacity())
-            .finish()
+pub struct BufferTransaction<'a> {
+    glue: &'a BufferGlue,
+    handles: Vec<(bool, u32)>,
+}
+
+impl<'call> BufferTransaction<'call> {
+    pub unsafe fn push_in_raw<'a, T>(&mut self, buffer: &'a [T]) -> i32
+    where
+        'a: 'call,
+    {
+        let mut inner = self.glue.inner.borrow_mut();
+        let handle = inner.in_buffers.insert(Buffer {
+            len: u32::try_from(buffer.len()).unwrap(),
+            kind: Input::Bytes(buffer.as_ptr() as *const u8, mem::size_of::<T>()),
+        });
+        self.handles.push((false, handle));
+        return handle as i32;
+    }
+
+    pub unsafe fn push_in<'a, T, F>(
+        &mut self,
+        iter: &'a mut (dyn ExactSizeIterator<Item = T> + 'a),
+        write: &'a F,
+    ) -> i32
+    where
+        F: Fn(&Memory, i32, T) -> Result<i32, Trap> + 'a,
+        'a: 'call,
+    {
+        let mut inner = self.glue.inner.borrow_mut();
+        let handle = inner.in_buffers.insert(Buffer {
+            len: u32::try_from(iter.len()).unwrap(),
+            kind: Input::General {
+                shim: shim::<T, F>,
+                iterator: mem::transmute(iter),
+                serialize: write as *const F as *const u8,
+            },
+        });
+        self.handles.push((false, handle));
+        return handle as i32;
+
+        unsafe fn shim<T, F>(
+            iter: [usize; 2],
+            serialize: *const u8,
+            memory: &Memory,
+            mut offset: i32,
+            len: u32,
+            processed: &mut u32,
+        ) -> Result<(), Trap>
+        where
+            F: Fn(&Memory, i32, T) -> Result<i32, Trap>,
+        {
+            let iter = mem::transmute::<_, &mut dyn ExactSizeIterator<Item = T>>(iter);
+            let write = &*(serialize as *const F);
+            for _ in 0..len {
+                let item = iter.next().unwrap();
+                offset += write(memory, offset, item)?;
+                *processed += 1;
+            }
+            Ok(())
+        }
+    }
+
+    pub unsafe fn push_out_raw<'a, T>(&mut self, buffer: &'a mut [T]) -> i32
+    where
+        'a: 'call,
+    {
+        let mut inner = self.glue.inner.borrow_mut();
+        let handle = inner.out_buffers.insert(Buffer {
+            len: u32::try_from(buffer.len()).unwrap(),
+            kind: Output::Bytes(buffer.as_mut_ptr() as *mut u8, mem::size_of::<T>()),
+        });
+        self.handles.push((true, handle));
+        return handle as i32;
+    }
+
+    pub unsafe fn push_out<'a, T, F>(&mut self, dst: &'a mut Vec<T>, read: &'a F) -> i32
+    where
+        F: Fn(&Memory, i32) -> Result<(T, i32), Trap> + 'a,
+        'a: 'call,
+    {
+        let mut inner = self.glue.inner.borrow_mut();
+        let handle = inner.out_buffers.insert(Buffer {
+            len: u32::try_from(dst.capacity() - dst.len()).unwrap(),
+            kind: Output::General {
+                shim: shim::<T, F>,
+                dst: dst as *mut Vec<T> as *mut u8,
+                deserialize: read as *const F as *const u8,
+            },
+        });
+        self.handles.push((true, handle));
+        return handle as i32;
+
+        unsafe fn shim<T, F>(
+            dst: *mut u8,
+            deserialize: *const u8,
+            memory: &Memory,
+            mut offset: i32,
+            len: u32,
+        ) -> Result<(), Trap>
+        where
+            F: Fn(&Memory, i32) -> Result<(T, i32), Trap>,
+        {
+            let dst = &mut *(dst as *mut Vec<T>);
+            let read = &*(deserialize as *const F);
+            for _ in 0..len {
+                let (item, size) = read(memory, offset)?;
+                dst.push(item);
+                offset += size;
+            }
+            Ok(())
+        }
     }
 }
+
+impl Drop for BufferTransaction<'_> {
+    fn drop(&mut self) {
+        let mut inner = self.glue.inner.borrow_mut();
+        for (out, handle) in self.handles.iter() {
+            if *out {
+                inner.out_buffers.remove(*handle);
+            } else {
+                inner.in_buffers.remove(*handle);
+            }
+        }
+    }
+}
+
+///// Implementation of `(in-buffer T)`.
+/////
+///// Holds a region of memory to store into as well as an iterator of items to
+///// serialize when calling an API.
+//pub struct InBuffer<'a, T> {
+//    storage: &'a mut [u8],
+//    items: &'a mut dyn Iterator<Item = T>,
+//}
+
+//impl<'a, T: 'a> InBuffer<'a, T> {
+//    /// Creates a new buffer where `items` are serialized into `storage` when
+//    /// this buffer is passed to a function call.
+//    ///
+//    /// # Panics
+//    ///
+//    /// `storage` must be large enough to store all the `items`
+//    /// provided. This will panic otherwise when passed to a callee.
+//    pub fn new(storage: &'a mut [u8], items: &'a mut dyn Iterator<Item = T>) -> InBuffer<'a, T> {
+//        InBuffer { storage, items }
+//    }
+
+//    /// Called from adapters with implementation of how to serialize.
+//    #[doc(hidden)]
+//    pub fn serialize<F, const N: usize>(&mut self, mut write: F) -> Result<&[u8], Trap>
+//    where
+//        F: FnMut(&mut [u8], T) -> Result<(), Trap>,
+//    {
+//        let mut len = 0;
+//        for (i, item) in self.items.enumerate() {
+//            let storage = &mut self.storage[N * i..][..N];
+//            write(storage, item)?;
+//            len += 1;
+//        }
+//        Ok(&self.storage[..len * N])
+//    }
+//}
+
+//impl<T> fmt::Debug for InBuffer<'_, T> {
+//    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//        f.debug_struct("InBuffer")
+//            .field("bytes", &self.storage.len())
+//            .finish()
+//    }
+//}
+
+///// Implementation of `(out-buffer T)`
+//pub struct OutBuffer<'a, T: 'a> {
+//    storage: &'a mut [u8],
+//    deserialize: fn(&[u8]) -> T,
+//    element_size: usize,
+//}
+
+//impl<'a, T: 'a> OutBuffer<'a, T> {
+//    /// Creates a new buffer with `storage` as where to store raw byte given to
+//    /// the host from wasm.
+//    ///
+//    /// The `storage` should be appropriately sized to hold the desired number
+//    /// of items to receive.
+//    pub fn new(storage: &'a mut [u8]) -> OutBuffer<'a, T> {
+//        OutBuffer {
+//            storage,
+//            deserialize: |_| loop {},
+//            element_size: usize::max_value(),
+//        }
+//    }
+
+//    #[doc(hidden)]
+//    pub fn storage(
+//        &mut self,
+//        _: usize,
+//        _: impl Fn(&[u8]) -> Result<T, Trap> + Clone + 'static,
+//    ) -> &mut [u8] {
+//        &mut *self.storage
+//    }
+
+//    ///// Called from adapters with implementation of how to deserialize.
+//    //#[doc(hidden)]
+//    //pub fn ptr_len<const N: usize>(&mut self, deserialize: fn(i32) -> T) -> (i32, i32) {
+//    //    self.element_size = N;
+//    //    self.deserialize = deserialize;
+//    //    (
+//    //        self.storage.as_ptr() as i32,
+//    //        (self.storage.len() / N) as i32,
+//    //    )
+//    //}
+
+//    ///// Consumes this output buffer, returning an iterator of the deserialized
+//    ///// version of all items that callee wrote.
+//    /////
+//    ///// This is `unsafe` because the `amt` here is not known to be valid, and
+//    ///// deserializing arbitrary bytes is not safe. The callee should always
+//    ///// indicate how many items were written into this output buffer by some
+//    ///// other means.
+//    //pub unsafe fn into_iter(self, amt: usize) -> impl Iterator<Item = T> + 'a
+//    //where
+//    //    T: 'a,
+//    //{
+//    //    let size = self.element_size;
+//    //    (0..amt)
+//    //        .map(move |i| i * size)
+//    //        .map(move |i| (self.deserialize)(self.storage[i..][..size].as_mut_ptr() as i32))
+//    //    // TODO: data is leaked if this iterator isn't run in full
+//    //}
+//}
+
+//impl<T> fmt::Debug for OutBuffer<'_, T> {
+//    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//        f.debug_struct("OutBuffer")
+//            .field("bytes", &self.storage.len())
+//            .finish()
+//    }
+//}

--- a/crates/wasmtime/src/imports.rs
+++ b/crates/wasmtime/src/imports.rs
@@ -1,415 +1,90 @@
-use crate::slab::Slab;
-use std::cell::RefCell;
-use std::convert::TryFrom;
+use crate::BorrowChecker;
+use std::fmt;
 use std::mem;
-use std::rc::Rc;
-use wasmtime::{Memory, Trap};
+use wasmtime::Trap;
 
-#[derive(Default, Clone)]
-pub struct BufferGlue {
-    inner: Rc<RefCell<Inner>>,
+pub struct PullBuffer<'a, T> {
+    mem: &'a [u8],
+    size: usize,
+    deserialize: &'a (dyn Fn(&'a [u8]) -> Result<T, Trap> + Send + Sync + 'a),
 }
 
-#[derive(Default)]
-struct Inner {
-    in_buffers: Slab<Buffer<Input>>,
-    out_buffers: Slab<Buffer<Output>>,
-}
-
-struct Buffer<T> {
-    len: u32,
-    kind: T,
-}
-
-enum Input {
-    Bytes(*const u8, usize),
-    General {
-        shim: unsafe fn([usize; 2], *const u8, &Memory, i32, u32, &mut u32) -> Result<(), Trap>,
-        iterator: [usize; 2],
-        serialize: *const u8,
-    },
-}
-
-enum Output {
-    Bytes(*mut u8, usize),
-    General {
-        shim: unsafe fn(*mut u8, *const u8, &Memory, i32, u32) -> Result<(), Trap>,
-        dst: *mut u8,
-        deserialize: *const u8,
-    },
-}
-
-impl BufferGlue {
-    pub fn transaction(&self) -> BufferTransaction<'_> {
-        BufferTransaction {
-            handles: Vec::new(),
-            glue: self,
-        }
+impl<'a, T> PullBuffer<'a, T> {
+    pub fn new(
+        mem: &mut BorrowChecker<'a>,
+        offset: i32,
+        len: i32,
+        size: i32,
+        deserialize: &'a (dyn Fn(&'a [u8]) -> Result<T, Trap> + Send + Sync + 'a),
+    ) -> Result<PullBuffer<'a, T>, Trap> {
+        Ok(PullBuffer {
+            mem: mem.slice(offset, len.saturating_mul(size))?,
+            size: size as usize,
+            deserialize,
+        })
     }
 
-    pub fn in_len(&self, handle: u32) -> Result<u32, Trap> {
-        let mut inner = self.inner.borrow_mut();
-        let b = inner
-            .in_buffers
-            .get_mut(handle)
-            .ok_or_else(|| Trap::new("invalid in-buffer handle"))?;
-        Ok(b.len)
+    pub fn len(&self) -> usize {
+        self.mem.len() / self.size
     }
 
-    /// Implementation of the canonical abi "in_read" function
-    pub fn in_read(
-        &self,
-        handle: u32,
-        store: impl wasmtime::AsContextMut,
-        memory: &wasmtime::Memory,
-        base: u32,
-        len: u32,
-    ) -> Result<(), Trap> {
-        let mut inner = self.inner.borrow_mut();
-        let b = inner
-            .in_buffers
-            .get_mut(handle)
-            .ok_or_else(|| Trap::new("invalid in-buffer handle"))?;
-        if len > b.len {
-            return Err(Trap::new(
-                "more items requested from in-buffer than are available",
-            ));
-        }
-        unsafe {
-            match &mut b.kind {
-                Input::Bytes(ptr, elem_size) => {
-                    let write_size = (len as usize) * *elem_size;
-                    memory
-                        .write(
-                            store,
-                            base as usize,
-                            std::slice::from_raw_parts(*ptr, write_size),
-                        )
-                        .map_err(|_| Trap::new("out-of-bounds write while reading in-buffer"))?;
-                    *ptr = (*ptr).add(write_size);
-                    b.len -= len;
-                    Ok(())
-                }
-                &mut Input::General {
-                    shim,
-                    iterator,
-                    serialize,
-                } => {
-                    drop(inner);
-                    let mut processed = 0;
-                    let res = shim(
-                        iterator,
-                        serialize,
-                        memory,
-                        base as i32,
-                        len,
-                        &mut processed,
-                    );
-                    self.inner
-                        .borrow_mut()
-                        .in_buffers
-                        .get_mut(handle)
-                        .expect("should still be there")
-                        .len -= processed;
-                    res
-                }
+    pub fn iter(&self) -> impl Iterator<Item = Result<T, Trap>> + 'a {
+        let deserialize = self.deserialize;
+        self.mem.chunks(self.size).map(deserialize)
+    }
+}
+
+impl<T> fmt::Debug for PullBuffer<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PullBuffer")
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
+pub struct PushBuffer<'a, T> {
+    mem: &'a mut [u8],
+    size: usize,
+    serialize: &'a (dyn Fn(&mut [u8], T) -> Result<(), Trap> + Send + Sync + 'a),
+}
+
+impl<'a, T> PushBuffer<'a, T> {
+    pub fn new(
+        mem: &mut BorrowChecker<'a>,
+        offset: i32,
+        len: i32,
+        size: i32,
+        serialize: &'a (dyn Fn(&mut [u8], T) -> Result<(), Trap> + Send + Sync + 'a),
+    ) -> Result<PushBuffer<'a, T>, Trap> {
+        let mem = mem.slice_mut(offset, (len as u32).saturating_mul(size as u32) as i32)?;
+        Ok(PushBuffer {
+            mem,
+            size: size as usize,
+            serialize,
+        })
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.mem.len() / self.size
+    }
+
+    pub fn write(&mut self, iter: impl IntoIterator<Item = T>) -> Result<(), Trap> {
+        for item in iter {
+            if self.mem.len() == 0 {
+                return Err(Trap::new("too many results in `PushBuffer::write`"));
             }
+            let (chunk, rest) = mem::take(&mut self.mem).split_at_mut(self.size);
+            self.mem = rest;
+            (self.serialize)(chunk, item)?;
         }
-    }
-
-    pub fn out_len(&self, handle: u32) -> Result<u32, Trap> {
-        let mut inner = self.inner.borrow_mut();
-        let b = inner
-            .out_buffers
-            .get_mut(handle)
-            .ok_or_else(|| Trap::new("out in-buffer handle"))?;
-        Ok(b.len)
-    }
-
-    /// Implementation of the canonical abi "out_write" function
-    pub fn out_write(
-        &self,
-        handle: u32,
-        store: impl wasmtime::AsContext,
-        memory: &wasmtime::Memory,
-        base: u32,
-        len: u32,
-    ) -> Result<(), Trap> {
-        let mut inner = self.inner.borrow_mut();
-        let b = inner
-            .out_buffers
-            .get_mut(handle)
-            .ok_or_else(|| Trap::new("invalid out-buffer handle"))?;
-        if len > b.len {
-            return Err(Trap::new(
-                "more items written to out-buffer than are available",
-            ));
-        }
-        unsafe {
-            match &mut b.kind {
-                Output::Bytes(ptr, elem_size) => {
-                    let read_size = (len as usize) * *elem_size;
-                    memory
-                        .read(
-                            &store,
-                            base as usize,
-                            std::slice::from_raw_parts_mut(*ptr, read_size),
-                        )
-                        .map_err(|_| Trap::new("out-of-bounds read while writing to out-buffer"))?;
-                    *ptr = (*ptr).add(read_size);
-                    b.len -= len;
-                    Ok(())
-                }
-                &mut Output::General {
-                    shim,
-                    dst,
-                    deserialize,
-                } => {
-                    shim(dst, deserialize, memory, base as i32, len)?;
-                    b.len -= len;
-                    Ok(())
-                }
-            }
-        }
+        Ok(())
     }
 }
 
-pub struct BufferTransaction<'a> {
-    glue: &'a BufferGlue,
-    handles: Vec<(bool, u32)>,
-}
-
-impl<'call> BufferTransaction<'call> {
-    pub unsafe fn push_in_raw<'a, T>(&mut self, buffer: &'a [T]) -> i32
-    where
-        'a: 'call,
-    {
-        let mut inner = self.glue.inner.borrow_mut();
-        let handle = inner.in_buffers.insert(Buffer {
-            len: u32::try_from(buffer.len()).unwrap(),
-            kind: Input::Bytes(buffer.as_ptr() as *const u8, mem::size_of::<T>()),
-        });
-        self.handles.push((false, handle));
-        return handle as i32;
-    }
-
-    pub unsafe fn push_in<'a, T, F>(
-        &mut self,
-        iter: &'a mut (dyn ExactSizeIterator<Item = T> + 'a),
-        write: &'a F,
-    ) -> i32
-    where
-        F: Fn(&Memory, i32, T) -> Result<i32, Trap> + 'a,
-        'a: 'call,
-    {
-        let mut inner = self.glue.inner.borrow_mut();
-        let handle = inner.in_buffers.insert(Buffer {
-            len: u32::try_from(iter.len()).unwrap(),
-            kind: Input::General {
-                shim: shim::<T, F>,
-                iterator: mem::transmute(iter),
-                serialize: write as *const F as *const u8,
-            },
-        });
-        self.handles.push((false, handle));
-        return handle as i32;
-
-        unsafe fn shim<T, F>(
-            iter: [usize; 2],
-            serialize: *const u8,
-            memory: &Memory,
-            mut offset: i32,
-            len: u32,
-            processed: &mut u32,
-        ) -> Result<(), Trap>
-        where
-            F: Fn(&Memory, i32, T) -> Result<i32, Trap>,
-        {
-            let iter = mem::transmute::<_, &mut dyn ExactSizeIterator<Item = T>>(iter);
-            let write = &*(serialize as *const F);
-            for _ in 0..len {
-                let item = iter.next().unwrap();
-                offset += write(memory, offset, item)?;
-                *processed += 1;
-            }
-            Ok(())
-        }
-    }
-
-    pub unsafe fn push_out_raw<'a, T>(&mut self, buffer: &'a mut [T]) -> i32
-    where
-        'a: 'call,
-    {
-        let mut inner = self.glue.inner.borrow_mut();
-        let handle = inner.out_buffers.insert(Buffer {
-            len: u32::try_from(buffer.len()).unwrap(),
-            kind: Output::Bytes(buffer.as_mut_ptr() as *mut u8, mem::size_of::<T>()),
-        });
-        self.handles.push((true, handle));
-        return handle as i32;
-    }
-
-    pub unsafe fn push_out<'a, T, F>(&mut self, dst: &'a mut Vec<T>, read: &'a F) -> i32
-    where
-        F: Fn(&Memory, i32) -> Result<(T, i32), Trap> + 'a,
-        'a: 'call,
-    {
-        let mut inner = self.glue.inner.borrow_mut();
-        let handle = inner.out_buffers.insert(Buffer {
-            len: u32::try_from(dst.capacity() - dst.len()).unwrap(),
-            kind: Output::General {
-                shim: shim::<T, F>,
-                dst: dst as *mut Vec<T> as *mut u8,
-                deserialize: read as *const F as *const u8,
-            },
-        });
-        self.handles.push((true, handle));
-        return handle as i32;
-
-        unsafe fn shim<T, F>(
-            dst: *mut u8,
-            deserialize: *const u8,
-            memory: &Memory,
-            mut offset: i32,
-            len: u32,
-        ) -> Result<(), Trap>
-        where
-            F: Fn(&Memory, i32) -> Result<(T, i32), Trap>,
-        {
-            let dst = &mut *(dst as *mut Vec<T>);
-            let read = &*(deserialize as *const F);
-            for _ in 0..len {
-                let (item, size) = read(memory, offset)?;
-                dst.push(item);
-                offset += size;
-            }
-            Ok(())
-        }
+impl<T> fmt::Debug for PushBuffer<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PushBuffer")
+            .field("capacity", &self.capacity())
+            .finish()
     }
 }
-
-impl Drop for BufferTransaction<'_> {
-    fn drop(&mut self) {
-        let mut inner = self.glue.inner.borrow_mut();
-        for (out, handle) in self.handles.iter() {
-            if *out {
-                inner.out_buffers.remove(*handle);
-            } else {
-                inner.in_buffers.remove(*handle);
-            }
-        }
-    }
-}
-
-///// Implementation of `(in-buffer T)`.
-/////
-///// Holds a region of memory to store into as well as an iterator of items to
-///// serialize when calling an API.
-//pub struct InBuffer<'a, T> {
-//    storage: &'a mut [u8],
-//    items: &'a mut dyn Iterator<Item = T>,
-//}
-
-//impl<'a, T: 'a> InBuffer<'a, T> {
-//    /// Creates a new buffer where `items` are serialized into `storage` when
-//    /// this buffer is passed to a function call.
-//    ///
-//    /// # Panics
-//    ///
-//    /// `storage` must be large enough to store all the `items`
-//    /// provided. This will panic otherwise when passed to a callee.
-//    pub fn new(storage: &'a mut [u8], items: &'a mut dyn Iterator<Item = T>) -> InBuffer<'a, T> {
-//        InBuffer { storage, items }
-//    }
-
-//    /// Called from adapters with implementation of how to serialize.
-//    #[doc(hidden)]
-//    pub fn serialize<F, const N: usize>(&mut self, mut write: F) -> Result<&[u8], Trap>
-//    where
-//        F: FnMut(&mut [u8], T) -> Result<(), Trap>,
-//    {
-//        let mut len = 0;
-//        for (i, item) in self.items.enumerate() {
-//            let storage = &mut self.storage[N * i..][..N];
-//            write(storage, item)?;
-//            len += 1;
-//        }
-//        Ok(&self.storage[..len * N])
-//    }
-//}
-
-//impl<T> fmt::Debug for InBuffer<'_, T> {
-//    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//        f.debug_struct("InBuffer")
-//            .field("bytes", &self.storage.len())
-//            .finish()
-//    }
-//}
-
-///// Implementation of `(out-buffer T)`
-//pub struct OutBuffer<'a, T: 'a> {
-//    storage: &'a mut [u8],
-//    deserialize: fn(&[u8]) -> T,
-//    element_size: usize,
-//}
-
-//impl<'a, T: 'a> OutBuffer<'a, T> {
-//    /// Creates a new buffer with `storage` as where to store raw byte given to
-//    /// the host from wasm.
-//    ///
-//    /// The `storage` should be appropriately sized to hold the desired number
-//    /// of items to receive.
-//    pub fn new(storage: &'a mut [u8]) -> OutBuffer<'a, T> {
-//        OutBuffer {
-//            storage,
-//            deserialize: |_| loop {},
-//            element_size: usize::max_value(),
-//        }
-//    }
-
-//    #[doc(hidden)]
-//    pub fn storage(
-//        &mut self,
-//        _: usize,
-//        _: impl Fn(&[u8]) -> Result<T, Trap> + Clone + 'static,
-//    ) -> &mut [u8] {
-//        &mut *self.storage
-//    }
-
-//    ///// Called from adapters with implementation of how to deserialize.
-//    //#[doc(hidden)]
-//    //pub fn ptr_len<const N: usize>(&mut self, deserialize: fn(i32) -> T) -> (i32, i32) {
-//    //    self.element_size = N;
-//    //    self.deserialize = deserialize;
-//    //    (
-//    //        self.storage.as_ptr() as i32,
-//    //        (self.storage.len() / N) as i32,
-//    //    )
-//    //}
-
-//    ///// Consumes this output buffer, returning an iterator of the deserialized
-//    ///// version of all items that callee wrote.
-//    /////
-//    ///// This is `unsafe` because the `amt` here is not known to be valid, and
-//    ///// deserializing arbitrary bytes is not safe. The callee should always
-//    ///// indicate how many items were written into this output buffer by some
-//    ///// other means.
-//    //pub unsafe fn into_iter(self, amt: usize) -> impl Iterator<Item = T> + 'a
-//    //where
-//    //    T: 'a,
-//    //{
-//    //    let size = self.element_size;
-//    //    (0..amt)
-//    //        .map(move |i| i * size)
-//    //        .map(move |i| (self.deserialize)(self.storage[i..][..size].as_mut_ptr() as i32))
-//    //    // TODO: data is leaked if this iterator isn't run in full
-//    //}
-//}
-
-//impl<T> fmt::Debug for OutBuffer<'_, T> {
-//    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//        f.debug_struct("OutBuffer")
-//            .field("bytes", &self.storage.len())
-//            .finish()
-//    }
-//}

--- a/crates/witx2/src/abi.rs
+++ b/crates/witx2/src/abi.rs
@@ -748,10 +748,6 @@ pub enum LiftLower {
 }
 
 /// Whether we are generating glue code to call an import or an export.
-///
-/// Note that this reflects the flavor of ABI we generate, and not necessarily
-/// the way the resulting bindings will be used by end users. See the comments
-/// on the `Direction` enum in wasmtime-impl for details.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Direction {
     /// We are generating glue code to call an import.

--- a/tests/runtime/buffers/host.rs
+++ b/tests/runtime/buffers/host.rs
@@ -1,8 +1,8 @@
-witx_bindgen_wasmtime::export!("./tests/runtime/buffers/imports.witx");
+witx_bindgen_wasmtime::import!("./tests/runtime/buffers/imports.witx");
 
 use anyhow::Result;
 use imports::*;
-use witx_bindgen_wasmtime::exports::{PullBuffer, PushBuffer};
+use witx_bindgen_wasmtime::imports::{PullBuffer, PushBuffer};
 use witx_bindgen_wasmtime::Le;
 
 #[derive(Default)]
@@ -115,7 +115,7 @@ impl Imports for MyImports {
     }
 }
 
-witx_bindgen_wasmtime::import!("./tests/runtime/buffers/exports.witx");
+witx_bindgen_wasmtime::export!("./tests/runtime/buffers/exports.witx");
 
 fn run(wasm: &str) -> Result<()> {
     use exports::*;

--- a/tests/runtime/flavorful/host.rs
+++ b/tests/runtime/flavorful/host.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-witx_bindgen_wasmtime::export!("./tests/runtime/flavorful/imports.witx");
+witx_bindgen_wasmtime::import!("./tests/runtime/flavorful/imports.witx");
 
 use imports::*;
 
@@ -91,7 +91,7 @@ impl Imports for MyImports {
     }
 }
 
-witx_bindgen_wasmtime::import!("./tests/runtime/flavorful/exports.witx");
+witx_bindgen_wasmtime::export!("./tests/runtime/flavorful/exports.witx");
 
 fn run(wasm: &str) -> Result<()> {
     use exports::*;

--- a/tests/runtime/handles/host.rs
+++ b/tests/runtime/handles/host.rs
@@ -1,4 +1,4 @@
-witx_bindgen_wasmtime::export!("./tests/runtime/handles/imports.witx");
+witx_bindgen_wasmtime::import!("./tests/runtime/handles/imports.witx");
 
 use anyhow::Result;
 use imports::*;
@@ -87,7 +87,7 @@ impl Imports for MyImports {
     fn odd_name_frob_the_odd(&mut self, _: &()) {}
 }
 
-witx_bindgen_wasmtime::import!("./tests/runtime/handles/exports.witx");
+witx_bindgen_wasmtime::export!("./tests/runtime/handles/exports.witx");
 
 fn run(wasm: &str) -> Result<()> {
     use exports::*;

--- a/tests/runtime/invalid/host.rs
+++ b/tests/runtime/invalid/host.rs
@@ -1,4 +1,4 @@
-witx_bindgen_wasmtime::export!("./tests/runtime/invalid/imports.witx");
+witx_bindgen_wasmtime::import!("./tests/runtime/invalid/imports.witx");
 
 use anyhow::Result;
 use imports::*;
@@ -36,7 +36,7 @@ impl Imports for MyImports {
     }
 }
 
-witx_bindgen_wasmtime::import!("./tests/runtime/invalid/exports.witx");
+witx_bindgen_wasmtime::export!("./tests/runtime/invalid/exports.witx");
 
 fn run(wasm: &str) -> Result<()> {
     use exports::*;

--- a/tests/runtime/lists/host.rs
+++ b/tests/runtime/lists/host.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-witx_bindgen_wasmtime::export!("./tests/runtime/lists/imports.witx");
+witx_bindgen_wasmtime::import!("./tests/runtime/lists/imports.witx");
 
 use imports::*;
 use witx_bindgen_wasmtime::Le;
@@ -122,7 +122,7 @@ impl Imports for MyImports {
     }
 }
 
-witx_bindgen_wasmtime::import!("./tests/runtime/lists/exports.witx");
+witx_bindgen_wasmtime::export!("./tests/runtime/lists/exports.witx");
 
 fn run(wasm: &str) -> Result<()> {
     use exports::*;

--- a/tests/runtime/numbers/host.rs
+++ b/tests/runtime/numbers/host.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-witx_bindgen_wasmtime::export!("./tests/runtime/numbers/imports.witx");
+witx_bindgen_wasmtime::import!("./tests/runtime/numbers/imports.witx");
 
 #[derive(Default)]
 pub struct MyImports {
@@ -61,7 +61,7 @@ impl imports::Imports for MyImports {
     }
 }
 
-witx_bindgen_wasmtime::import!("./tests/runtime/numbers/exports.witx");
+witx_bindgen_wasmtime::export!("./tests/runtime/numbers/exports.witx");
 
 fn run(wasm: &str) -> Result<()> {
     let (exports, mut store) = crate::instantiate(

--- a/tests/runtime/records/host.rs
+++ b/tests/runtime/records/host.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-witx_bindgen_wasmtime::export!("./tests/runtime/records/imports.witx");
+witx_bindgen_wasmtime::import!("./tests/runtime/records/imports.witx");
 
 use imports::*;
 
@@ -49,7 +49,7 @@ impl Imports for MyImports {
     }
 }
 
-witx_bindgen_wasmtime::import!("./tests/runtime/records/exports.witx");
+witx_bindgen_wasmtime::export!("./tests/runtime/records/exports.witx");
 
 fn run(wasm: &str) -> Result<()> {
     use exports::*;

--- a/tests/runtime/smoke/host.rs
+++ b/tests/runtime/smoke/host.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-witx_bindgen_wasmtime::export!("./tests/runtime/smoke/imports.witx");
+witx_bindgen_wasmtime::import!("./tests/runtime/smoke/imports.witx");
 
 #[derive(Default)]
 pub struct MyImports {
@@ -14,7 +14,7 @@ impl imports::Imports for MyImports {
     }
 }
 
-witx_bindgen_wasmtime::import!("./tests/runtime/smoke/exports.witx");
+witx_bindgen_wasmtime::export!("./tests/runtime/smoke/exports.witx");
 
 fn run(wasm: &str) -> Result<()> {
     let (exports, mut store) = crate::instantiate(

--- a/tests/runtime/smw_functions/host.rs
+++ b/tests/runtime/smw_functions/host.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 
-witx_bindgen_wasmtime::export!("tests/runtime/smw_functions/imports.witx");
+witx_bindgen_wasmtime::import!("tests/runtime/smw_functions/imports.witx");
 
 #[derive(Default)]
 pub struct Host {
@@ -47,7 +47,7 @@ impl imports::Imports for Host {
     }
 }
 
-witx_bindgen_wasmtime::import!("tests/runtime/smw_functions/exports.witx");
+witx_bindgen_wasmtime::export!("tests/runtime/smw_functions/exports.witx");
 
 fn run(wasm: &str) -> anyhow::Result<()> {
     let (exports, mut store) = crate::instantiate_smw(

--- a/tests/runtime/smw_lists/host.rs
+++ b/tests/runtime/smw_lists/host.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use witx_bindgen_wasmtime::Le;
 
-witx_bindgen_wasmtime::export!("tests/runtime/smw_lists/imports.witx");
+witx_bindgen_wasmtime::import!("tests/runtime/smw_lists/imports.witx");
 
 #[derive(Default)]
 pub struct Host {
@@ -37,7 +37,7 @@ impl imports::Imports for Host {
     }
 }
 
-witx_bindgen_wasmtime::import!("tests/runtime/smw_lists/exports.witx");
+witx_bindgen_wasmtime::export!("tests/runtime/smw_lists/exports.witx");
 
 fn run(wasm: &str) -> anyhow::Result<()> {
     let (exports, mut store) = crate::instantiate_smw(

--- a/tests/runtime/smw_strings/host.rs
+++ b/tests/runtime/smw_strings/host.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 
-witx_bindgen_wasmtime::export!("tests/runtime/smw_strings/imports.witx");
+witx_bindgen_wasmtime::import!("tests/runtime/smw_strings/imports.witx");
 
 #[derive(Default)]
 pub struct Host {
@@ -29,7 +29,7 @@ impl imports::Imports for Host {
     }
 }
 
-witx_bindgen_wasmtime::import!("tests/runtime/smw_strings/exports.witx");
+witx_bindgen_wasmtime::export!("tests/runtime/smw_strings/exports.witx");
 
 fn run(wasm: &str) -> anyhow::Result<()> {
     let (exports, mut store) = crate::instantiate_smw(

--- a/tests/runtime/variants/host.rs
+++ b/tests/runtime/variants/host.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-witx_bindgen_wasmtime::export!("./tests/runtime/variants/imports.witx");
+witx_bindgen_wasmtime::import!("./tests/runtime/variants/imports.witx");
 
 use imports::*;
 
@@ -51,7 +51,7 @@ impl Imports for MyImports {
     }
 }
 
-witx_bindgen_wasmtime::import!("./tests/runtime/variants/exports.witx");
+witx_bindgen_wasmtime::export!("./tests/runtime/variants/exports.witx");
 
 fn run(wasm: &str) -> Result<()> {
     use exports::*;


### PR DESCRIPTION
This reverts commit bd86bed02a84b595a2a56ca105d29e5f7e4f1605.

I've been doing work on the async bindings for Wasmtime and for the life
of me I can no longer keep import/export straight, so I'm proposing that
this change is reverted. The usage of import/export was only changed on
the surface for witx-bindgen tooling but it means that reading and
writing the internals of witx-bindgen many operations feel backwards and
I forget what is mapped where and which end swapped what.

This reopens the problem that the import/export terminology for the host
(you're not "importing" functionality but rather providing an import to
wasm) but I personally feel that in the long run there's got to be a
better solution than using import/export at all. For example profiles I
think are promising where it's one unit to talk about and profiles
themselves say what they require and what they provide. I'm hoping that
a refactoring in the future or changing how the tooling works will solve
the user-facing problem, but for now while witx-bindgen is under heavy
development I find myself frequently tripping up to these swapped terms
since internally witx-bindgen is now inconsistent.