### PR TITLE
Rename Direction to AbiVariant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,9 @@ $ witx-bindgen rust-wasm --export my-interface.witx
 $ witx-bindgen wasmtime --import host-functions.witx
 ```
 
-Here "import" means "imported by WebAssembly" and "export" means
-"exported by WebAssembly". This means that wasm files import APIs with
-`--import`, whereas hosts provide imports to wasm modules using `--import` (the
-terminology here [can be
-confusing](https://github.com/bytecodealliance/witx-bindgen/issues/34)
+Here "import" means "I want to import and call the functions in this interface"
+and "export" means "I want to define the functions in this interface for others
+to call".
 
 Finally in a sort of "miscellaneous" category the `witx-bindgen` CLI also
 supports:

--- a/crates/gen-c/src/lib.rs
+++ b/crates/gen-c/src/lib.rs
@@ -2,7 +2,7 @@ use heck::*;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::mem;
 use witx_bindgen_gen_core::witx2::abi::{
-    Bindgen, Bitcast, AbiVariant, Instruction, LiftLower, WasmType, WitxInstruction,
+    AbiVariant, Bindgen, Bitcast, Instruction, LiftLower, WasmType, WitxInstruction,
 };
 use witx_bindgen_gen_core::{witx2::*, Files, Generator, Ns};
 

--- a/crates/gen-core/src/lib.rs
+++ b/crates/gen-core/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::collections::{btree_map::Entry, BTreeMap, HashMap, HashSet};
 use std::ops::Deref;
 use std::path::Path;
-use witx2::abi::{Abi, Direction};
+use witx2::abi::{Abi, AbiVariant};
 use witx2::*;
 
 // pub use witx;
@@ -16,8 +16,8 @@ pub trait Generator {
         drop((imports, exports));
     }
 
-    fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
-        drop((iface, dir));
+    fn preprocess_one(&mut self, iface: &Interface, variant: AbiVariant) {
+        drop((iface, variant));
     }
 
     fn type_record(
@@ -75,8 +75,8 @@ pub trait Generator {
         drop(files);
     }
 
-    fn generate_one(&mut self, iface: &Interface, dir: Direction, files: &mut Files) {
-        self.preprocess_one(iface, dir);
+    fn generate_one(&mut self, iface: &Interface, variant: AbiVariant, files: &mut Files) {
+        self.preprocess_one(iface, variant);
 
         for (id, ty) in iface.types.iter() {
             // assert!(ty.foreign_module.is_none()); // TODO
@@ -109,9 +109,9 @@ pub trait Generator {
         // }
 
         for f in iface.functions.iter() {
-            match dir {
-                Direction::Import => self.import(iface, &f),
-                Direction::Export => self.export(iface, &f),
+            match variant {
+                AbiVariant::GuestImport => self.import(iface, &f),
+                AbiVariant::GuestExport => self.export(iface, &f),
             }
         }
 
@@ -122,11 +122,11 @@ pub trait Generator {
         self.preprocess_all(imports, exports);
 
         for imp in imports {
-            self.generate_one(imp, Direction::Import, files);
+            self.generate_one(imp, AbiVariant::GuestImport, files);
         }
 
         for exp in exports {
-            self.generate_one(exp, Direction::Export, files);
+            self.generate_one(exp, AbiVariant::GuestExport, files);
         }
 
         self.finish_all(files);

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -2,7 +2,7 @@ use heck::*;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::mem;
 use witx_bindgen_gen_core::witx2::abi::{
-    Bindgen, Bitcast, Direction, Instruction, LiftLower, WasmType, WitxInstruction,
+    Bindgen, Bitcast, AbiVariant, Instruction, LiftLower, WasmType, WitxInstruction,
 };
 use witx_bindgen_gen_core::{witx2::*, Files, Generator};
 
@@ -356,9 +356,9 @@ impl Js {
 }
 
 impl Generator for Js {
-    fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
-        self.sizes.fill(dir, iface);
-        self.in_import = dir == Direction::Import;
+    fn preprocess_one(&mut self, iface: &Interface, variant: AbiVariant) {
+        self.sizes.fill(variant, iface);
+        self.in_import = variant == AbiVariant::GuestImport;
     }
 
     fn type_record(
@@ -559,7 +559,7 @@ impl Generator for Js {
     fn import(&mut self, iface: &Interface, func: &Function) {
         let prev = mem::take(&mut self.src);
 
-        let sig = iface.wasm_signature(Direction::Import, func);
+        let sig = iface.wasm_signature(AbiVariant::GuestImport, func);
         let params = (0..sig.params.len())
             .map(|i| format!("arg{}", i))
             .collect::<Vec<_>>();
@@ -569,7 +569,7 @@ impl Generator for Js {
 
         let mut f = FunctionBindgen::new(self, false, params);
         iface.call(
-            Direction::Import,
+            AbiVariant::GuestImport,
             LiftLower::LiftArgsLowerResults,
             func,
             &mut f,
@@ -668,7 +668,7 @@ impl Generator for Js {
         let mut f = FunctionBindgen::new(self, false, params);
         f.src_object = src_object;
         iface.call(
-            Direction::Export,
+            AbiVariant::GuestExport,
             LiftLower::LowerArgsLiftResults,
             func,
             &mut f,

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -11,8 +11,8 @@ pub struct Js {
     src: Source,
     in_import: bool,
     opts: Opts,
-    imports: HashMap<String, Imports>,
-    exports: HashMap<String, Exports>,
+    guest_imports: HashMap<String, Imports>,
+    guest_exports: HashMap<String, Exports>,
     sizes: SizeAlign,
     intrinsics: BTreeMap<Intrinsic, String>,
     all_intrinsics: BTreeSet<Intrinsic>,
@@ -631,7 +631,7 @@ impl Generator for Js {
 
         let src = mem::replace(&mut self.src, prev);
         let imports = self
-            .imports
+            .guest_imports
             .entry(iface.name.to_string())
             .or_insert(Imports::default());
         let dst = match &func.kind {
@@ -727,7 +727,7 @@ impl Generator for Js {
         self.src.js("}\n");
 
         let exports = self
-            .exports
+            .guest_exports
             .entry(iface.name.to_string())
             .or_insert_with(Exports::default);
 
@@ -747,7 +747,7 @@ impl Generator for Js {
     }
 
     fn finish_one(&mut self, iface: &Interface, files: &mut Files) {
-        for (module, funcs) in mem::take(&mut self.imports) {
+        for (module, funcs) in mem::take(&mut self.guest_imports) {
             // TODO: `module.exports` vs `export function`
             self.src.js(&format!(
                 "export function add{}ToImports(imports, obj{}) {{\n",
@@ -835,7 +835,7 @@ impl Generator for Js {
         }
         let imports = mem::take(&mut self.src);
 
-        for (module, exports) in mem::take(&mut self.exports) {
+        for (module, exports) in mem::take(&mut self.guest_exports) {
             let module = module.to_camel_case();
             self.src.ts(&format!("export class {} {{\n", module));
             self.src.js(&format!("export class {} {{\n", module));

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -4,7 +4,7 @@ use std::mem;
 use witx_bindgen_gen_core::witx2::abi::{
     AbiVariant, Bindgen, Bitcast, Instruction, LiftLower, WasmType, WitxInstruction,
 };
-use witx_bindgen_gen_core::{witx2::*, Files, Generator};
+use witx_bindgen_gen_core::{witx2::*, Direction, Files, Generator};
 
 #[derive(Default)]
 pub struct Js {
@@ -110,6 +110,14 @@ impl Intrinsic {
 impl Js {
     pub fn new() -> Js {
         Js::default()
+    }
+
+    fn abi_variant(dir: Direction) -> AbiVariant {
+        // This generator uses the obvious direction to ABI variant mapping.
+        match dir {
+            Direction::Export => AbiVariant::GuestExport,
+            Direction::Import => AbiVariant::GuestImport,
+        }
     }
 
     fn is_nullable_option(&self, iface: &Interface, variant: &Variant) -> bool {
@@ -356,7 +364,8 @@ impl Js {
 }
 
 impl Generator for Js {
-    fn preprocess_one(&mut self, iface: &Interface, variant: AbiVariant) {
+    fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
+        let variant = Self::abi_variant(dir);
         self.sizes.fill(variant, iface);
         self.in_import = variant == AbiVariant::GuestImport;
     }

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -572,6 +572,9 @@ impl Generator for Js {
         self.src.ts(";\n");
     }
 
+    // As with `abi_variant` above, we're generating host-side bindings here
+    // so a user "export" uses the "guest import" ABI variant on the inside of
+    // this `Generator` implementation.
     fn export(&mut self, iface: &Interface, func: &Function) {
         let prev = mem::take(&mut self.src);
 
@@ -643,6 +646,9 @@ impl Generator for Js {
         dst.push((func.name.to_string(), src));
     }
 
+    // As with `abi_variant` above, we're generating host-side bindings here
+    // so a user "import" uses the "export" ABI variant on the inside of
+    // this `Generator` implementation.
     fn import(&mut self, iface: &Interface, func: &Function) {
         let prev = mem::take(&mut self.src);
 

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -2,7 +2,7 @@ use heck::*;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::mem;
 use witx_bindgen_gen_core::witx2::abi::{
-    Bindgen, Bitcast, AbiVariant, Instruction, LiftLower, WasmType, WitxInstruction,
+    AbiVariant, Bindgen, Bitcast, Instruction, LiftLower, WasmType, WitxInstruction,
 };
 use witx_bindgen_gen_core::{witx2::*, Files, Generator};
 

--- a/crates/gen-js/tests/codegen.rs
+++ b/crates/gen-js/tests/codegen.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 use std::process::Command;
 
-mod imports {
-    test_helpers::codegen_js_import!(
+mod exports {
+    test_helpers::codegen_js_export!(
         // ...
         "*.witx"
 
@@ -11,16 +11,16 @@ mod imports {
     );
 }
 
-mod exports {
-    test_helpers::codegen_js_export!(
+mod imports {
+    test_helpers::codegen_js_import!(
         "*.witx"
 
-        // This uses buffers, which we don't support in exports just yet
+        // This uses buffers, which we don't support in imports just yet
         // TODO: should support this
         "!wasi_next.witx"
         "!host.witx"
 
-        // These use the preview1 ABI which isn't implemented for JS exports.
+        // These use the preview1 ABI which isn't implemented for JS imports.
         "!wasi_snapshot_preview1.witx"
         "!typenames.witx"
         "!legacy.witx"

--- a/crates/gen-js/tests/runtime.rs
+++ b/crates/gen-js/tests/runtime.rs
@@ -14,12 +14,15 @@ fn execute(name: &str, wasm: &Path, ts: &Path, imports: &Path, exports: &Path) {
 
     println!("OUT_DIR = {:?}", dir);
     println!("Generating bindings...");
+    // We call `generate_all` with exports from the imports.witx file, and
+    // imports from the exports.witx witx file. It's reversed because we're
+    // implementing the host side of these APIs.
     let imports = witx_bindgen_gen_core::witx2::Interface::parse_file(imports).unwrap();
     let exports = witx_bindgen_gen_core::witx2::Interface::parse_file(exports).unwrap();
     let mut files = Default::default();
     witx_bindgen_gen_js::Opts::default()
         .build()
-        .generate_all(&[imports], &[exports], &mut files);
+        .generate_all(&[exports], &[imports], &mut files);
     for (file, contents) in files.iter() {
         fs::write(dir.join(file), contents).unwrap();
     }

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -1,9 +1,9 @@
 use heck::*;
 use pulldown_cmark::{html, Event, LinkType, Parser, Tag};
 use std::collections::HashMap;
-use witx2::abi::AbiVariant;
 use witx2::*;
-use witx_bindgen_gen_core::{witx2, Files, Generator, Source};
+use witx_bindgen_gen_core::witx2::abi::AbiVariant;
+use witx_bindgen_gen_core::{witx2, Direction, Files, Generator, Source};
 
 #[derive(Default)]
 pub struct Markdown {
@@ -32,6 +32,14 @@ impl Opts {
 impl Markdown {
     pub fn new() -> Markdown {
         Markdown::default()
+    }
+
+    fn abi_variant(dir: Direction) -> AbiVariant {
+        // This generator uses the obvious direction to ABI variant mapping.
+        match dir {
+            Direction::Export => AbiVariant::GuestExport,
+            Direction::Import => AbiVariant::GuestImport,
+        }
     }
 
     fn print_ty(&mut self, iface: &Interface, ty: &Type, skip_name: bool) {
@@ -169,7 +177,8 @@ impl Markdown {
 }
 
 impl Generator for Markdown {
-    fn preprocess_one(&mut self, iface: &Interface, variant: AbiVariant) {
+    fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
+        let variant = Self::abi_variant(dir);
         self.sizes.fill(variant, iface);
     }
 

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -1,7 +1,7 @@
 use heck::*;
 use pulldown_cmark::{html, Event, LinkType, Parser, Tag};
 use std::collections::HashMap;
-use witx2::abi::Direction;
+use witx2::abi::AbiVariant;
 use witx2::*;
 use witx_bindgen_gen_core::{witx2, Files, Generator, Source};
 
@@ -169,8 +169,8 @@ impl Markdown {
 }
 
 impl Generator for Markdown {
-    fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
-        self.sizes.fill(dir, iface);
+    fn preprocess_one(&mut self, iface: &Interface, variant: AbiVariant) {
+        self.sizes.fill(variant, iface);
     }
 
     fn type_record(

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Stdio};
 use witx_bindgen_gen_core::witx2::abi::{
     AbiVariant, Bindgen, Instruction, LiftLower, WasmType, WitxInstruction,
 };
-use witx_bindgen_gen_core::{witx2::*, Files, Generator, Source, TypeInfo, Types};
+use witx_bindgen_gen_core::{witx2::*, Direction, Files, Generator, Source, TypeInfo, Types};
 use witx_bindgen_gen_rust::{
     int_repr, wasm_type, FnSig, RustFunctionGenerator, RustGenerator, TypeMode,
 };
@@ -70,6 +70,14 @@ impl Opts {
 impl RustWasm {
     pub fn new() -> RustWasm {
         RustWasm::default()
+    }
+
+    fn abi_variant(dir: Direction) -> AbiVariant {
+        // This generator uses the obvious direction to ABI variant mapping.
+        match dir {
+            Direction::Export => AbiVariant::GuestExport,
+            Direction::Import => AbiVariant::GuestImport,
+        }
     }
 }
 
@@ -207,7 +215,8 @@ impl RustGenerator for RustWasm {
 }
 
 impl Generator for RustWasm {
-    fn preprocess_one(&mut self, iface: &Interface, variant: AbiVariant) {
+    fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
+        let variant = Self::abi_variant(dir);
         self.in_import = variant == AbiVariant::GuestImport;
         self.types.analyze(iface);
         self.trait_name = iface.name.to_camel_case();

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 use std::mem;
 use std::process::{Command, Stdio};
 use witx_bindgen_gen_core::witx2::abi::{
-    Bindgen, AbiVariant, Instruction, LiftLower, WasmType, WitxInstruction,
+    AbiVariant, Bindgen, Instruction, LiftLower, WasmType, WitxInstruction,
 };
 use witx_bindgen_gen_core::{witx2::*, Files, Generator, Source, TypeInfo, Types};
 use witx_bindgen_gen_rust::{

--- a/crates/gen-spidermonkey/src/lib.rs
+++ b/crates/gen-spidermonkey/src/lib.rs
@@ -905,11 +905,11 @@ impl Generator for SpiderMonkeyWasm<'_> {
         // Figure out what the maximum return pointer area we will need is.
         for (iface, dir) in imports
             .iter()
-            .zip(std::iter::repeat(witx2::abi::Direction::Import))
+            .zip(std::iter::repeat(witx2::abi::AbiVariant::GuestImport))
             .chain(
                 exports
                     .iter()
-                    .zip(std::iter::repeat(witx2::abi::Direction::Export)),
+                    .zip(std::iter::repeat(witx2::abi::AbiVariant::GuestExport)),
             )
         {
             for func in iface.functions.iter() {
@@ -922,7 +922,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
         }
     }
 
-    fn preprocess_one(&mut self, iface: &witx2::Interface, dir: witx2::abi::Direction) {
+    fn preprocess_one(&mut self, iface: &witx2::Interface, dir: witx2::abi::AbiVariant) {
         self.sizes.fill(dir, iface);
     }
 
@@ -1036,7 +1036,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
         );
 
         // Add the raw Wasm import.
-        let wasm_sig = iface.wasm_signature(witx2::abi::Direction::Import, func);
+        let wasm_sig = iface.wasm_signature(witx2::abi::AbiVariant::GuestImport, func);
         let type_index = self.intern_type(wasm_sig.clone());
         let import_fn_index = self.witx_import(self.imports.len());
         self.imports.import(
@@ -1065,7 +1065,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
             witx2::abi::LiftLower::LowerArgsLiftResults,
         );
         iface.call(
-            witx2::abi::Direction::Import,
+            witx2::abi::AbiVariant::GuestImport,
             witx2::abi::LiftLower::LowerArgsLiftResults,
             func,
             &mut bindgen,
@@ -1081,7 +1081,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
             "We only support the canonical ABI right now"
         );
 
-        let wasm_sig = iface.wasm_signature(witx2::abi::Direction::Export, func);
+        let wasm_sig = iface.wasm_signature(witx2::abi::AbiVariant::GuestExport, func);
         let type_index = self.intern_type(wasm_sig.clone());
         let export_fn_index = self.witx_export(self.exports.len());
         self.exports
@@ -1096,7 +1096,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
             witx2::abi::LiftLower::LiftArgsLowerResults,
         );
         iface.call(
-            witx2::abi::Direction::Export,
+            witx2::abi::AbiVariant::GuestExport,
             witx2::abi::LiftLower::LiftArgsLowerResults,
             func,
             &mut bindgen,

--- a/crates/gen-spidermonkey/src/lib.rs
+++ b/crates/gen-spidermonkey/src/lib.rs
@@ -15,9 +15,9 @@ use wasm_encoder::Instruction;
 use witx_bindgen_gen_core::{
     witx2::{
         self,
-        abi::{WasmSignature, WasmType},
+        abi::{AbiVariant, WasmSignature, WasmType},
     },
-    Files, Generator,
+    Direction, Files, Generator,
 };
 
 #[allow(missing_docs)]
@@ -385,6 +385,14 @@ impl<'a> SpiderMonkeyWasm<'a> {
             sizes: Default::default(),
             function_names: Vec::new(),
             local_names: Vec::new(),
+        }
+    }
+
+    fn abi_variant(dir: Direction) -> AbiVariant {
+        // This generator uses the obvious direction to ABI variant mapping.
+        match dir {
+            Direction::Export => AbiVariant::GuestExport,
+            Direction::Import => AbiVariant::GuestImport,
         }
     }
 
@@ -903,17 +911,17 @@ impl Generator for SpiderMonkeyWasm<'_> {
             Some(u32::try_from(exports.iter().map(|i| i.functions.len()).sum::<usize>()).unwrap());
 
         // Figure out what the maximum return pointer area we will need is.
-        for (iface, dir) in imports
+        for (iface, variant) in imports
             .iter()
-            .zip(std::iter::repeat(witx2::abi::AbiVariant::GuestImport))
+            .zip(std::iter::repeat(AbiVariant::GuestImport))
             .chain(
                 exports
                     .iter()
-                    .zip(std::iter::repeat(witx2::abi::AbiVariant::GuestExport)),
+                    .zip(std::iter::repeat(AbiVariant::GuestExport)),
             )
         {
             for func in iface.functions.iter() {
-                let sig = iface.wasm_signature(dir, func);
+                let sig = iface.wasm_signature(variant, func);
                 if let Some(results) = sig.retptr {
                     self.i64_return_pointer_area_size =
                         self.i64_return_pointer_area_size.max(results.len());
@@ -922,8 +930,8 @@ impl Generator for SpiderMonkeyWasm<'_> {
         }
     }
 
-    fn preprocess_one(&mut self, iface: &witx2::Interface, dir: witx2::abi::AbiVariant) {
-        self.sizes.fill(dir, iface);
+    fn preprocess_one(&mut self, iface: &witx2::Interface, dir: Direction) {
+        self.sizes.fill(Self::abi_variant(dir), iface);
     }
 
     fn type_record(
@@ -1036,7 +1044,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
         );
 
         // Add the raw Wasm import.
-        let wasm_sig = iface.wasm_signature(witx2::abi::AbiVariant::GuestImport, func);
+        let wasm_sig = iface.wasm_signature(AbiVariant::GuestImport, func);
         let type_index = self.intern_type(wasm_sig.clone());
         let import_fn_index = self.witx_import(self.imports.len());
         self.imports.import(
@@ -1065,7 +1073,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
             witx2::abi::LiftLower::LowerArgsLiftResults,
         );
         iface.call(
-            witx2::abi::AbiVariant::GuestImport,
+            AbiVariant::GuestImport,
             witx2::abi::LiftLower::LowerArgsLiftResults,
             func,
             &mut bindgen,
@@ -1081,7 +1089,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
             "We only support the canonical ABI right now"
         );
 
-        let wasm_sig = iface.wasm_signature(witx2::abi::AbiVariant::GuestExport, func);
+        let wasm_sig = iface.wasm_signature(AbiVariant::GuestExport, func);
         let type_index = self.intern_type(wasm_sig.clone());
         let export_fn_index = self.witx_export(self.exports.len());
         self.exports
@@ -1096,7 +1104,7 @@ impl Generator for SpiderMonkeyWasm<'_> {
             witx2::abi::LiftLower::LiftArgsLowerResults,
         );
         iface.call(
-            witx2::abi::AbiVariant::GuestExport,
+            AbiVariant::GuestExport,
             witx2::abi::LiftLower::LiftArgsLowerResults,
             func,
             &mut bindgen,

--- a/crates/gen-wasmtime-py/src/lib.rs
+++ b/crates/gen-wasmtime-py/src/lib.rs
@@ -4,7 +4,7 @@ use std::mem;
 use witx_bindgen_gen_core::witx2::abi::{
     AbiVariant, Bindgen, Bitcast, Instruction, LiftLower, WasmType, WitxInstruction,
 };
-use witx_bindgen_gen_core::{witx2::*, Files, Generator, Ns};
+use witx_bindgen_gen_core::{witx2::*, Direction, Files, Generator, Ns};
 
 #[derive(Default)]
 pub struct WasmtimePy {
@@ -71,6 +71,14 @@ impl Opts {
 impl WasmtimePy {
     pub fn new() -> WasmtimePy {
         WasmtimePy::default()
+    }
+
+    fn abi_variant(dir: Direction) -> AbiVariant {
+        // This generator uses the obvious direction to ABI variant mapping.
+        match dir {
+            Direction::Export => AbiVariant::GuestExport,
+            Direction::Import => AbiVariant::GuestImport,
+        }
     }
 
     fn indent(&mut self) {
@@ -630,7 +638,8 @@ impl WasmtimePy {
 }
 
 impl Generator for WasmtimePy {
-    fn preprocess_one(&mut self, iface: &Interface, variant: AbiVariant) {
+    fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
+        let variant = Self::abi_variant(dir);
         self.sizes.fill(variant, iface);
         self.in_import = variant == AbiVariant::GuestImport;
     }

--- a/crates/gen-wasmtime-py/src/lib.rs
+++ b/crates/gen-wasmtime-py/src/lib.rs
@@ -2,7 +2,7 @@ use heck::*;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::mem;
 use witx_bindgen_gen_core::witx2::abi::{
-    Bindgen, Bitcast, AbiVariant, Instruction, LiftLower, WasmType, WitxInstruction,
+    AbiVariant, Bindgen, Bitcast, Instruction, LiftLower, WasmType, WitxInstruction,
 };
 use witx_bindgen_gen_core::{witx2::*, Files, Generator, Ns};
 

--- a/crates/gen-wasmtime-py/src/lib.rs
+++ b/crates/gen-wasmtime-py/src/lib.rs
@@ -846,6 +846,9 @@ impl Generator for WasmtimePy {
         self.src.push_str("\n");
     }
 
+    // As with `abi_variant` above, we're generating host-side bindings here
+    // so a user "export" uses the "guest import" ABI variant on the inside of
+    // this `Generator` implementation.
     fn export(&mut self, iface: &Interface, func: &Function) {
         assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
@@ -960,6 +963,9 @@ impl Generator for WasmtimePy {
         dst.push(import);
     }
 
+    // As with `abi_variant` above, we're generating host-side bindings here
+    // so a user "import" uses the "export" ABI variant on the inside of
+    // this `Generator` implementation.
     fn import(&mut self, iface: &Interface, func: &Function) {
         assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);

--- a/crates/gen-wasmtime-py/src/lib.rs
+++ b/crates/gen-wasmtime-py/src/lib.rs
@@ -2,7 +2,7 @@ use heck::*;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::mem;
 use witx_bindgen_gen_core::witx2::abi::{
-    Bindgen, Bitcast, Direction, Instruction, LiftLower, WasmType, WitxInstruction,
+    Bindgen, Bitcast, AbiVariant, Instruction, LiftLower, WasmType, WitxInstruction,
 };
 use witx_bindgen_gen_core::{witx2::*, Files, Generator, Ns};
 
@@ -630,9 +630,9 @@ impl WasmtimePy {
 }
 
 impl Generator for WasmtimePy {
-    fn preprocess_one(&mut self, iface: &Interface, dir: Direction) {
-        self.sizes.fill(dir, iface);
-        self.in_import = dir == Direction::Import;
+    fn preprocess_one(&mut self, iface: &Interface, variant: AbiVariant) {
+        self.sizes.fill(variant, iface);
+        self.in_import = variant == AbiVariant::GuestImport;
     }
 
     fn type_record(
@@ -837,7 +837,7 @@ impl Generator for WasmtimePy {
         self.print_sig(iface, func);
         let pysig = mem::take(&mut self.src).into();
 
-        let sig = iface.wasm_signature(Direction::Import, func);
+        let sig = iface.wasm_signature(AbiVariant::GuestImport, func);
         self.src.push_str(&format!(
             "def {}(caller: wasmtime.Caller",
             func.name.to_snake_case(),
@@ -862,7 +862,7 @@ impl Generator for WasmtimePy {
 
         let mut f = FunctionBindgen::new(self, params);
         iface.call(
-            Direction::Import,
+            AbiVariant::GuestImport,
             LiftLower::LiftArgsLowerResults,
             func,
             &mut f,
@@ -960,7 +960,7 @@ impl Generator for WasmtimePy {
         let mut f = FunctionBindgen::new(self, params);
         f.src_object = src_object;
         iface.call(
-            Direction::Export,
+            AbiVariant::GuestExport,
             LiftLower::LowerArgsLiftResults,
             func,
             &mut f,

--- a/crates/gen-wasmtime-py/tests/codegen.rs
+++ b/crates/gen-wasmtime-py/tests/codegen.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 use std::process::Command;
 
-mod imports {
-    test_helpers::codegen_py_import!(
+mod exports {
+    test_helpers::codegen_py_export!(
         "*.witx"
 
         // TODO: implement async support
@@ -15,19 +15,19 @@ mod imports {
     );
 }
 
-mod exports {
-    test_helpers::codegen_py_export!(
+mod imports {
+    test_helpers::codegen_py_import!(
         "*.witx"
 
         // TODO: implement async support
         "!async_functions.witx"
 
-        // This uses buffers, which we don't support in exports just yet
+        // This uses buffers, which we don't support in imports just yet
         // TODO: should support this
         "!wasi_next.witx"
         "!host.witx"
 
-        // These use the preview1 ABI which isn't implemented for C exports.
+        // These use the preview1 ABI which isn't implemented for Python imports.
         "!wasi_snapshot_preview1.witx"
         "!typenames.witx"
         "!legacy.witx"

--- a/crates/gen-wasmtime-py/tests/runtime.rs
+++ b/crates/gen-wasmtime-py/tests/runtime.rs
@@ -16,11 +16,14 @@ fn execute(name: &str, wasm: &Path, py: &Path, imports: &Path, exports: &Path) {
 
     println!("OUT_DIR = {:?}", dir);
     println!("Generating bindings...");
+    // We call `generate_all` with exports from the imports.witx file, and
+    // imports from the exports.witx witx file. It's reversed because we're
+    // implementing the host side of these APIs.
     let iface = witx_bindgen_gen_core::witx2::Interface::parse_file(imports).unwrap();
     let mut files = Default::default();
     witx_bindgen_gen_wasmtime_py::Opts::default()
         .build()
-        .generate_all(&[iface], &[], &mut files);
+        .generate_all(&[], &[iface], &mut files);
     for (file, contents) in files.iter() {
         fs::write(dir.join("imports").join(file), contents).unwrap();
     }
@@ -30,7 +33,7 @@ fn execute(name: &str, wasm: &Path, py: &Path, imports: &Path, exports: &Path) {
     let mut files = Default::default();
     witx_bindgen_gen_wasmtime_py::Opts::default()
         .build()
-        .generate_all(&[], &[iface], &mut files);
+        .generate_all(&[iface], &[], &mut files);
     for (file, contents) in files.iter() {
         fs::write(dir.join("exports").join(file), contents).unwrap();
     }

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -584,6 +584,9 @@ impl Generator for Wasmtime {
     //     ));
     // }
 
+    // As with `abi_variant` above, we're generating host-side bindings here
+    // so a user "export" uses the "guest import" ABI variant on the inside of
+    // this `Generator` implementation.
     fn export(&mut self, iface: &Interface, func: &Function) {
         assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);
@@ -766,6 +769,9 @@ impl Generator for Wasmtime {
             });
     }
 
+    // As with `abi_variant` above, we're generating host-side bindings here
+    // so a user "import" uses the "export" ABI variant on the inside of
+    // this `Generator` implementation.
     fn import(&mut self, iface: &Interface, func: &Function) {
         assert!(!func.is_async, "async not supported yet");
         let prev = mem::take(&mut self.src);

--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 use witx_bindgen_gen_core::witx2::abi::{
-    Abi, Bindgen, AbiVariant, Instruction, LiftLower, WasmType, WitxInstruction,
+    Abi, AbiVariant, Bindgen, Instruction, LiftLower, WasmType, WitxInstruction,
 };
 use witx_bindgen_gen_core::{witx2::*, Files, Generator, Source, TypeInfo, Types};
 use witx_bindgen_gen_rust::{

--- a/crates/rust-wasm-impl/src/lib.rs
+++ b/crates/rust-wasm-impl/src/lib.rs
@@ -2,26 +2,25 @@ use proc_macro::TokenStream;
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{token, Token};
-use witx2::abi::AbiVariant;
-use witx_bindgen_gen_core::{witx2, Files, Generator};
+use witx_bindgen_gen_core::{witx2, Direction, Files, Generator};
 
 #[proc_macro]
 pub fn import(input: TokenStream) -> TokenStream {
-    run(input, AbiVariant::GuestImport)
+    run(input, Direction::Import)
 }
 
 #[proc_macro]
 pub fn export(input: TokenStream) -> TokenStream {
-    run(input, AbiVariant::GuestExport)
+    run(input, Direction::Export)
 }
 
-fn run(input: TokenStream, dir: AbiVariant) -> TokenStream {
+fn run(input: TokenStream, dir: Direction) -> TokenStream {
     let input = syn::parse_macro_input!(input as Opts);
     let mut gen = input.opts.build();
     let mut files = Files::default();
     let (imports, exports) = match dir {
-        AbiVariant::GuestImport => (input.interfaces, vec![]),
-        AbiVariant::GuestExport => (vec![], input.interfaces),
+        Direction::Import => (input.interfaces, vec![]),
+        Direction::Export => (vec![], input.interfaces),
     };
     gen.generate_all(&imports, &exports, &mut files);
     let (_, contents) = files.iter().next().unwrap();

--- a/crates/rust-wasm-impl/src/lib.rs
+++ b/crates/rust-wasm-impl/src/lib.rs
@@ -2,26 +2,26 @@ use proc_macro::TokenStream;
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{token, Token};
-use witx2::abi::Direction;
+use witx2::abi::AbiVariant;
 use witx_bindgen_gen_core::{witx2, Files, Generator};
 
 #[proc_macro]
 pub fn import(input: TokenStream) -> TokenStream {
-    run(input, Direction::Import)
+    run(input, AbiVariant::GuestImport)
 }
 
 #[proc_macro]
 pub fn export(input: TokenStream) -> TokenStream {
-    run(input, Direction::Export)
+    run(input, AbiVariant::GuestExport)
 }
 
-fn run(input: TokenStream, dir: Direction) -> TokenStream {
+fn run(input: TokenStream, dir: AbiVariant) -> TokenStream {
     let input = syn::parse_macro_input!(input as Opts);
     let mut gen = input.opts.build();
     let mut files = Files::default();
     let (imports, exports) = match dir {
-        Direction::Import => (input.interfaces, vec![]),
-        Direction::Export => (vec![], input.interfaces),
+        AbiVariant::GuestImport => (input.interfaces, vec![]),
+        AbiVariant::GuestExport => (vec![], input.interfaces),
     };
     gen.generate_all(&imports, &exports, &mut files);
     let (_, contents) = files.iter().next().unwrap();

--- a/crates/test-helpers/src/lib.rs
+++ b/crates/test-helpers/src/lib.rs
@@ -4,18 +4,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
-use witx_bindgen_gen_core::Generator;
-
-/// This is the direction from the user's perspective. Are we importing
-/// functions to call, or defining functions and exporting them to be called?
-///
-/// This differs from the `witx2::abi::Direction` value in some bindings; see
-/// the comments on the `Direction` enum in wasmtime-impl for details.
-#[derive(PartialEq, Eq, Copy, Clone)]
-enum Direction {
-    Import,
-    Export,
-}
+use witx_bindgen_gen_core::{Direction, Generator};
 
 #[proc_macro]
 #[cfg(feature = "witx-bindgen-gen-rust-wasm")]

--- a/crates/test-helpers/src/lib.rs
+++ b/crates/test-helpers/src/lib.rs
@@ -287,16 +287,16 @@ pub fn codegen_wasmtime_import(input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 #[cfg(feature = "witx-bindgen-gen-js")]
-pub fn codegen_js_import(input: TokenStream) -> TokenStream {
-    gen_verify(input, Direction::Import, "import", || {
+pub fn codegen_js_export(input: TokenStream) -> TokenStream {
+    gen_verify(input, Direction::Export, "export", || {
         witx_bindgen_gen_js::Opts::default().build()
     })
 }
 
 #[proc_macro]
 #[cfg(feature = "witx-bindgen-gen-js")]
-pub fn codegen_js_export(input: TokenStream) -> TokenStream {
-    gen_verify(input, Direction::Export, "export", || {
+pub fn codegen_js_import(input: TokenStream) -> TokenStream {
+    gen_verify(input, Direction::Import, "import", || {
         witx_bindgen_gen_js::Opts::default().build()
     })
 }
@@ -319,16 +319,16 @@ pub fn codegen_c_export(input: TokenStream) -> TokenStream {
 
 #[proc_macro]
 #[cfg(feature = "witx-bindgen-gen-wasmtime-py")]
-pub fn codegen_py_import(input: TokenStream) -> TokenStream {
-    gen_verify(input, Direction::Import, "import", || {
+pub fn codegen_py_export(input: TokenStream) -> TokenStream {
+    gen_verify(input, Direction::Export, "export", || {
         witx_bindgen_gen_wasmtime_py::Opts::default().build()
     })
 }
 
 #[proc_macro]
 #[cfg(feature = "witx-bindgen-gen-wasmtime-py")]
-pub fn codegen_py_export(input: TokenStream) -> TokenStream {
-    gen_verify(input, Direction::Export, "export", || {
+pub fn codegen_py_import(input: TokenStream) -> TokenStream {
+    gen_verify(input, Direction::Import, "import", || {
         witx_bindgen_gen_wasmtime_py::Opts::default().build()
     })
 }

--- a/crates/wasmlink/src/module.rs
+++ b/crates/wasmlink/src/module.rs
@@ -9,7 +9,7 @@ use wasmparser::{
     SectionReader, Type, TypeDef, Validator,
 };
 use witx2::{
-    abi::{Direction, WasmSignature, WasmType},
+    abi::{AbiVariant, WasmSignature, WasmType},
     Function, SizeAlign,
 };
 
@@ -86,8 +86,8 @@ impl Interface {
             .functions
             .iter()
             .map(|f| {
-                let import_signature = inner.wasm_signature(Direction::Import, f);
-                let export_signature = inner.wasm_signature(Direction::Export, f);
+                let import_signature = inner.wasm_signature(AbiVariant::GuestImport, f);
+                let export_signature = inner.wasm_signature(AbiVariant::GuestExport, f);
                 let import_type = Self::sig_to_type(&import_signature);
                 let export_type = Self::sig_to_type(&export_signature);
 
@@ -119,7 +119,7 @@ impl Interface {
             .collect();
 
         let mut sizes = SizeAlign::default();
-        sizes.fill(Direction::Export, &inner);
+        sizes.fill(AbiVariant::GuestExport, &inner);
 
         let has_resources = inner
             .resources

--- a/crates/wasmtime-impl/src/lib.rs
+++ b/crates/wasmtime-impl/src/lib.rs
@@ -2,33 +2,8 @@ use proc_macro::TokenStream;
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{token, Token};
-use witx_bindgen_gen_core::{witx2, Files, Generator};
+use witx_bindgen_gen_core::{witx2, Direction, Files, Generator};
 use witx_bindgen_gen_wasmtime::Async;
-
-/// This is the direction from the user's perspective. Are we importing
-/// functions to call, or defining functions and exporting them to be called?
-///
-/// In the wasmtime bindings, this is the opposite of the witx2::abi::Direction
-/// value, because these bindings work differently from other bindings:
-///
-/// In a wasm-calling-wasm use case, one wasm module would use the `Import`
-/// ABI, the other would use the `Export` ABI, and there would be an adapter
-/// layer between the two that translates from one ABI to the other.
-///
-/// With wasm-calling-host, we don't go through a separate adapter layer;
-/// the binding code we generate on the host side just does everything
-/// itself. So when the host is conceptually "exporting" a function to
-/// wasm, it uses the `Import` ABI so that wasm can also use the `Import`
-/// ABI and import it directly from the host.
-///
-/// These are all implementation details; from the user perspective, it's
-/// just: `export` means I'm exporting functions to be called, `import`
-/// means I'm importing functions that I'm going to call, in both wasm
-/// modules and host code. The enum here represents this user perspective.
-enum Direction {
-    Import,
-    Export,
-}
 
 /// Generate code to support consuming the given interfaces, importaing them
 /// from wasm modules.

--- a/crates/witx-bindgen-demo/build.sh
+++ b/crates/witx-bindgen-demo/build.sh
@@ -9,8 +9,8 @@ cargo build -p witx-bindgen-demo --target wasm32-unknown-unknown --release
 cp target/wasm32-unknown-unknown/release/witx_bindgen_demo.wasm static/demo.wasm
 
 cargo run js \
-  --import crates/witx-bindgen-demo/browser.witx \
-  --export crates/witx-bindgen-demo/demo.witx \
+  --export crates/witx-bindgen-demo/browser.witx \
+  --import crates/witx-bindgen-demo/demo.witx \
   --out-dir static
 
 cp crates/witx-bindgen-demo/{index.html,main.ts} static/

--- a/crates/witx2/src/abi.rs
+++ b/crates/witx2/src/abi.rs
@@ -1365,7 +1365,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                                 AbiVariant::GuestImport => 2,
                             }
                         } else {
-                            (sig.retptr.is_some() && self.variant == AbiVariant::GuestImport) as usize
+                            (sig.retptr.is_some() && self.variant == AbiVariant::GuestImport)
+                                as usize
                         };
                         sig.params.len() - skip_cnt
                     }
@@ -1817,7 +1818,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     let mut results = Vec::new();
                     let mut temp = Vec::new();
                     let mut casts = Vec::new();
-                    self.iface.push_wasm(self.abi, self.variant, ty, &mut results);
+                    self.iface
+                        .push_wasm(self.abi, self.variant, ty, &mut results);
                     for (i, case) in v.cases.iter().enumerate() {
                         self.push_block();
                         self.emit(&VariantPayloadName);
@@ -2128,7 +2130,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     let mut params = Vec::new();
                     let mut temp = Vec::new();
                     let mut casts = Vec::new();
-                    self.iface.push_wasm(self.abi, self.variant, ty, &mut params);
+                    self.iface
+                        .push_wasm(self.abi, self.variant, ty, &mut params);
                     let block_inputs = self
                         .stack
                         .drain(self.stack.len() + 1 - params.len()..)

--- a/crates/witx2/src/abi.rs
+++ b/crates/witx2/src/abi.rs
@@ -752,7 +752,7 @@ pub enum LiftLower {
 ///
 /// Note that this reflects the flavor of ABI we generate, and not necessarily
 /// the way the resulting bindings will be used by end users. See the comments
-/// on the `AbiVariant` enum in wasmtime-impl for details.
+/// on the `Direction` enum in gen-core for details.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum AbiVariant {
     /// We are generating glue code to call an import.

--- a/crates/witx2/src/abi.rs
+++ b/crates/witx2/src/abi.rs
@@ -753,11 +753,18 @@ pub enum LiftLower {
 /// Note that this reflects the flavor of ABI we generate, and not necessarily
 /// the way the resulting bindings will be used by end users. See the comments
 /// on the `Direction` enum in gen-core for details.
+///
+/// The bindings ABI has a concept of a "guest" and a "host". Wasmlink can
+/// generate glue to bridge between two "guests", but in that case each side
+/// thinks of the glue as the "host". There are two variants of the ABI,
+/// one specialized for the "guest" importing and calling a function defined
+/// and exported in the "host", and the other specialized for the "host"
+/// importing and calling a fuinction defined and exported in the "guest".
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum AbiVariant {
-    /// We are generating glue code to call an import.
+    /// The guest is importing and calling the function.
     GuestImport,
-    /// We are generating glue code to call an export.
+    /// The guest is defining and exporting the function.
     GuestExport,
 }
 


### PR DESCRIPTION
And rename Import and Export to GuestImport and GuestExport.

As discussed in #94, this renames `witx2::abi::Direction` to `witx2::abi::AbiVariant`, and its `Import` and `Export` to `GuestImport` and `GuestExport. More refactoring is needed; this is a first step. I'm also open to other names here.

The big picture is that the direction switch happens at the `Generator` interface. Code calling the `Generator` interface uses `Direction` and the developer perspective, and code inside `Generator` implementations use `AbiVariant` and the ABI perspective. In particular, the `imports` and `exports` members of the `Wasmtime` type are inside the wasmtime `Generator` implementation, so they use the ABI perspective.

The `preprocess_one` is the one outstanding exception to this I'm aware of; it currently takes an `AbiVariant` argument passed in from the outside. ~~If this overall plan makes sense, I'll submit a follow-up PR to adjust `preprocess_one` to be consistent with the `Generator` boundary.~~ Edit: It was pretty straightforward, so I've now added a patch to adjust `preprocess_one` to this PR.